### PR TITLE
Sync with changes from NEURON for nrnunits.lib

### DIFF
--- a/share/nrnunits.lib
+++ b/share/nrnunits.lib
@@ -1,4 +1,7 @@
 / from gnu units distribution
+/ Nov, 2017 updated faraday, R, e, planck, hbar, mole, k according to
+/ https://physics.nist.gov/cuu/Constants/index.html
+
 / primitive units
 
 m			*a*
@@ -65,7 +68,9 @@ c			2.99792458+8 m/sec fuzz
 g			9.80665 m/sec2
 au			1.49597871+11 m fuzz
 mole			6.022169+23 fuzz
+/mole			6.022140857+23 fuzz
 e			1.6021917-19 coul fuzz
+/e			1.6021766208-19 coul fuzz
 energy			c2
 force			g
 mercury			1.33322+5 kg/m2-sec2
@@ -389,6 +394,7 @@ ev			e-volt
 / faraday  from  host: physics.nist.gov
 /          	 path: /PhysRefData/fundconst/html/keywords.html
 faraday			9.6485309+4 coul
+/faraday			96485.33289 coul
 fathom			6 ft
 fermi			1-15 m
 fifth			4|5 qt
@@ -424,6 +430,8 @@ hyl			gm force sec2/m
 hz			/sec
 imaginarycubicfoot	1.4 ft3
 jeroboam		4|5 gal
+boltzmann		1.38064852-23 joule/K
+k			boltzmann
 karat			1|24
 kcal			kilocal
 kcalorie		kilocal
@@ -491,6 +499,8 @@ quarter			9 in
 quartersection		1|4 mi2
 quintal			100 kg
 quire			25
+gasconstant		8.3144598 joule/K
+R			gasconstant
 rad			100 erg/gm
 ream			500
 registerton		100 ft3
@@ -543,8 +553,6 @@ wey			40 bu
 weymass			252 lb
 Xunit			1.00202-13m
 degC			K
-k			1.38047-16 erg/degC
-
 
 kelvin			K
 brewster		1-12 m2/newton
@@ -561,7 +569,9 @@ englishell		45 inch
 scottishell		37.2 inch
 flemishell		27 inch
 planck			6.626-34 joule-sec
+/planck			6.626070040-34 joule-sec
 hbar			1.055-34 joule-sec
+/hbar			1.054571800-34 joule-sec
 electronmass		9.1095-31 kg
 protonmass		1.6726-27 kg
 neutronmass		1.6606-27 kg


### PR DESCRIPTION
Corresponding commit in nrnhines/nrn is

https://github.com/nrnhines/nrn/commit/e0950a19a722b661882d1609fe7748ec67b68ba8