### PR TITLE
Add support for thread safe euler method (similar to NEURON)

### DIFF
--- a/src/mod2c_core/deriv.c
+++ b/src/mod2c_core/deriv.c
@@ -193,6 +193,19 @@ numeqn, listnum, listnum, fun->name, suffix);
 	  "extern int %s%s_thread(int, int*, int*, int, _threadargsproto_);\n"
 	  , ssprefix, method->name);
 	linsertstr(procfunc, buf);
+
+    if(strcmp(method->name, "euler") == 0) {
+        Sprintf(buf,
+          "\n"
+          "/* _euler_ %s %s */\n"
+          "#ifndef INSIDE_NMODL\n"
+          "#define INSIDE_NMODL\n"
+          "#endif\n"
+          "#include \"_kinderiv.h\"\n"
+          , fun->name, suffix);
+        Linsertstr(procfunc, buf);
+    }
+
 	}else{ /* kinetic */
    if (vectorize) {
 Sprintf(buf,
@@ -523,6 +536,7 @@ void massagederiv(q1, q2, q3, q4, sensused)
 	}
 
 	deriv_implicit_really = 0;
+
 	if (deriv_imp_really) ITERATE(q, deriv_imp_really) {
 		if (strcmp(derfun->name, STR(q)) == 0) {
 			deriv_implicit_really = 1;

--- a/src/mod2c_core/deriv.c
+++ b/src/mod2c_core/deriv.c
@@ -194,6 +194,8 @@ numeqn, listnum, listnum, fun->name, suffix);
 	  , ssprefix, method->name);
 	linsertstr(procfunc, buf);
 
+    // euler_thread is defined externally and need a callback function
+    // selection of callback is using switch-case implemented in _kinderiv.h
     if(strcmp(method->name, "euler") == 0) {
         Sprintf(buf,
           "\n"

--- a/src/mod2c_core/solve.c
+++ b/src/mod2c_core/solve.c
@@ -129,6 +129,9 @@ diag("The SOLVE statement must be before the DERIVATIVE block for ", SYM(lq)->na
 			cvode_cnexp_solve = lq;
 #endif
 		}
+		if (strcmp(SYM(q2)->name, "euler") == 0) {
+			add_deriv_imp_really(SYM(q1)->name);
+		}
 		delete(q2->prev);
 		delete(q2);
 	}else{
@@ -220,7 +223,7 @@ void solvhandler()
 			}
 			if (btype == BREAKPOINT && !steadystate) {
 				/* derivatives recalculated after while loop */
-if (strcmp(method->name, "cnexp") != 0 && strcmp(method->name, "derivimplicit") != 0) {
+if (strcmp(method->name, "cnexp") != 0 && strcmp(method->name, "derivimplicit") != 0 && strcmp(method->name, "euler") != 0) {
 fprintf(stderr, "Notice: %s is not thread safe. Complain to Hines\n", method->name);
 				vectorize = 0;
 				Sprintf(buf, " %s();\n", fun->name);

--- a/src/mod2c_core/solve.c
+++ b/src/mod2c_core/solve.c
@@ -129,6 +129,8 @@ diag("The SOLVE statement must be before the DERIVATIVE block for ", SYM(lq)->na
 			cvode_cnexp_solve = lq;
 #endif
 		}
+        // state functions for euler should be non-staic
+        // deriv_imp_really list is used to track those functions
 		if (strcmp(SYM(q2)->name, "euler") == 0) {
 			add_deriv_imp_really(SYM(q1)->name);
 		}


### PR DESCRIPTION
Similar to derivimplicit, included _kinderiv.h.

@nrnhines : call to `add_deriv_imp_really` seems to be safe as we use that only to decide if `static or non-static` declaration of state functions.