### PR TITLE
Fix random123 compiling error with latest clang 9 on OSX

### DIFF
--- a/src/mod2c_core/noccout.c
+++ b/src/mod2c_core/noccout.c
@@ -702,7 +702,7 @@ void c_out_vectorize()
 
 	/* things which must go first and most declarations */
 	P("/* VECTORIZED */\n");
-	P("#include <stdio.h>\n#include <stdlib.h>\n#include <math.h>\n#include \"coreneuron/mech/cfile/scoplib.h\"\n");
+	P("#include <stdio.h>\n#include <stdlib.h>\n#include <math.h>\n");
 	P("#undef PI\n");
 	printlist(defs_list);
 	printlist(firstlist);

--- a/src/mod2c_core/nocpout.c
+++ b/src/mod2c_core/nocpout.c
@@ -335,11 +335,12 @@ fprintf(stderr, "Notice: ARTIFICIAL_CELL models that would require thread specif
 	}
 
 	Lappendstr(defs_list, "\
+\n#include \"coreneuron/utils/randoms/nrnran123.h\"\
 \n#include \"coreneuron/nrnoc/md1redef.h\"\
 \n#include \"coreneuron/nrnconf.h\"\
 \n#include \"coreneuron/nrnoc/multicore.h\"\
 \n#include \"coreneuron/nrniv/nrn_acc_manager.h\"\
-\n#include \"coreneuron/utils/randoms/nrnran123.h\"\n\
+\n#include \"coreneuron/mech/cfile/scoplib.h\"\n\
 \n#include \"coreneuron/nrnoc/md2redef.h\"\
 \n#if METHOD3\nextern int _method3;\n#endif\n\
 \n#if !NRNGPU\

--- a/test/validation/mod2c_core/c/NaSm.c
+++ b/test/validation/mod2c_core/c/NaSm.c
@@ -3,14 +3,14 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <math.h>
-#include "coreneuron/mech/cfile/scoplib.h"
 #undef PI
  
+#include "coreneuron/utils/randoms/nrnran123.h"
 #include "coreneuron/nrnoc/md1redef.h"
 #include "coreneuron/nrnconf.h"
 #include "coreneuron/nrnoc/multicore.h"
 #include "coreneuron/nrniv/nrn_acc_manager.h"
-#include "coreneuron/utils/randoms/nrnran123.h"
+#include "coreneuron/mech/cfile/scoplib.h"
 
 #include "coreneuron/nrnoc/md2redef.h"
 #if METHOD3

--- a/test/validation/mod2c_core/c/Nap.c
+++ b/test/validation/mod2c_core/c/Nap.c
@@ -6,11 +6,12 @@
 #include "coreneuron/mech/cfile/scoplib.h"
 #undef PI
  
+#include "coreneuron/utils/randoms/nrnran123.h"
 #include "coreneuron/nrnoc/md1redef.h"
 #include "coreneuron/nrnconf.h"
 #include "coreneuron/nrnoc/multicore.h"
 #include "coreneuron/nrniv/nrn_acc_manager.h"
-#include "coreneuron/utils/randoms/nrnran123.h"
+#include "coreneuron/mech/cfile/scoplib.h"
 
 #include "coreneuron/nrnoc/md2redef.h"
 #if METHOD3

--- a/test/validation/mod2c_core/c/NapDA.c
+++ b/test/validation/mod2c_core/c/NapDA.c
@@ -3,14 +3,14 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <math.h>
-#include "coreneuron/mech/cfile/scoplib.h"
 #undef PI
  
+#include "coreneuron/utils/randoms/nrnran123.h"
 #include "coreneuron/nrnoc/md1redef.h"
 #include "coreneuron/nrnconf.h"
 #include "coreneuron/nrnoc/multicore.h"
 #include "coreneuron/nrniv/nrn_acc_manager.h"
-#include "coreneuron/utils/randoms/nrnran123.h"
+#include "coreneuron/mech/cfile/scoplib.h"
 
 #include "coreneuron/nrnoc/md2redef.h"
 #if METHOD3

--- a/test/validation/mod2c_core/c/NapIn.c
+++ b/test/validation/mod2c_core/c/NapIn.c
@@ -6,11 +6,12 @@
 #include "coreneuron/mech/cfile/scoplib.h"
 #undef PI
  
+#include "coreneuron/utils/randoms/nrnran123.h"
 #include "coreneuron/nrnoc/md1redef.h"
 #include "coreneuron/nrnconf.h"
 #include "coreneuron/nrnoc/multicore.h"
 #include "coreneuron/nrniv/nrn_acc_manager.h"
-#include "coreneuron/utils/randoms/nrnran123.h"
+#include "coreneuron/mech/cfile/scoplib.h"
 
 #include "coreneuron/nrnoc/md2redef.h"
 #if METHOD3

--- a/test/validation/mod2c_core/c/Nap_E.c
+++ b/test/validation/mod2c_core/c/Nap_E.c
@@ -3,14 +3,14 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <math.h>
-#include "coreneuron/mech/cfile/scoplib.h"
 #undef PI
  
+#include "coreneuron/utils/randoms/nrnran123.h"
 #include "coreneuron/nrnoc/md1redef.h"
 #include "coreneuron/nrnconf.h"
 #include "coreneuron/nrnoc/multicore.h"
 #include "coreneuron/nrniv/nrn_acc_manager.h"
-#include "coreneuron/utils/randoms/nrnran123.h"
+#include "coreneuron/mech/cfile/scoplib.h"
 
 #include "coreneuron/nrnoc/md2redef.h"
 #if METHOD3

--- a/test/validation/mod2c_core/c/Nap_No.c
+++ b/test/validation/mod2c_core/c/Nap_No.c
@@ -3,14 +3,14 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <math.h>
-#include "coreneuron/mech/cfile/scoplib.h"
 #undef PI
  
+#include "coreneuron/utils/randoms/nrnran123.h"
 #include "coreneuron/nrnoc/md1redef.h"
 #include "coreneuron/nrnconf.h"
 #include "coreneuron/nrnoc/multicore.h"
 #include "coreneuron/nrniv/nrn_acc_manager.h"
-#include "coreneuron/utils/randoms/nrnran123.h"
+#include "coreneuron/mech/cfile/scoplib.h"
 
 #include "coreneuron/nrnoc/md2redef.h"
 #if METHOD3

--- a/test/validation/mod2c_core/c/SynNMDA10_1.c
+++ b/test/validation/mod2c_core/c/SynNMDA10_1.c
@@ -6,11 +6,12 @@
 #include "coreneuron/mech/cfile/scoplib.h"
 #undef PI
  
+#include "coreneuron/utils/randoms/nrnran123.h"
 #include "coreneuron/nrnoc/md1redef.h"
 #include "coreneuron/nrnconf.h"
 #include "coreneuron/nrnoc/multicore.h"
 #include "coreneuron/nrniv/nrn_acc_manager.h"
-#include "coreneuron/utils/randoms/nrnran123.h"
+#include "coreneuron/mech/cfile/scoplib.h"
 
 #include "coreneuron/nrnoc/md2redef.h"
 #if METHOD3

--- a/test/validation/mod2c_core/c/SynNMDA10_2.c
+++ b/test/validation/mod2c_core/c/SynNMDA10_2.c
@@ -6,11 +6,12 @@
 #include "coreneuron/mech/cfile/scoplib.h"
 #undef PI
  
+#include "coreneuron/utils/randoms/nrnran123.h"
 #include "coreneuron/nrnoc/md1redef.h"
 #include "coreneuron/nrnconf.h"
 #include "coreneuron/nrnoc/multicore.h"
 #include "coreneuron/nrniv/nrn_acc_manager.h"
-#include "coreneuron/utils/randoms/nrnran123.h"
+#include "coreneuron/mech/cfile/scoplib.h"
 
 #include "coreneuron/nrnoc/md2redef.h"
 #if METHOD3

--- a/test/validation/mod2c_core/c/SynNMDA10_2_2.c
+++ b/test/validation/mod2c_core/c/SynNMDA10_2_2.c
@@ -3,14 +3,14 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <math.h>
-#include "coreneuron/mech/cfile/scoplib.h"
 #undef PI
  
+#include "coreneuron/utils/randoms/nrnran123.h"
 #include "coreneuron/nrnoc/md1redef.h"
 #include "coreneuron/nrnconf.h"
 #include "coreneuron/nrnoc/multicore.h"
 #include "coreneuron/nrniv/nrn_acc_manager.h"
-#include "coreneuron/utils/randoms/nrnran123.h"
+#include "coreneuron/mech/cfile/scoplib.h"
 
 #include "coreneuron/nrnoc/md2redef.h"
 #if METHOD3

--- a/test/validation/mod2c_core/c/SynNMDA16.c
+++ b/test/validation/mod2c_core/c/SynNMDA16.c
@@ -3,14 +3,14 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <math.h>
-#include "coreneuron/mech/cfile/scoplib.h"
 #undef PI
  
+#include "coreneuron/utils/randoms/nrnran123.h"
 #include "coreneuron/nrnoc/md1redef.h"
 #include "coreneuron/nrnconf.h"
 #include "coreneuron/nrnoc/multicore.h"
 #include "coreneuron/nrniv/nrn_acc_manager.h"
-#include "coreneuron/utils/randoms/nrnran123.h"
+#include "coreneuron/mech/cfile/scoplib.h"
 
 #include "coreneuron/nrnoc/md2redef.h"
 #if METHOD3

--- a/test/validation/mod2c_core/c/SynNMDA16_2.c
+++ b/test/validation/mod2c_core/c/SynNMDA16_2.c
@@ -3,14 +3,14 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <math.h>
-#include "coreneuron/mech/cfile/scoplib.h"
 #undef PI
  
+#include "coreneuron/utils/randoms/nrnran123.h"
 #include "coreneuron/nrnoc/md1redef.h"
 #include "coreneuron/nrnconf.h"
 #include "coreneuron/nrnoc/multicore.h"
 #include "coreneuron/nrniv/nrn_acc_manager.h"
-#include "coreneuron/utils/randoms/nrnran123.h"
+#include "coreneuron/mech/cfile/scoplib.h"
 
 #include "coreneuron/nrnoc/md2redef.h"
 #if METHOD3

--- a/test/validation/mod2c_core/c/is.c
+++ b/test/validation/mod2c_core/c/is.c
@@ -3,14 +3,14 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <math.h>
-#include "coreneuron/mech/cfile/scoplib.h"
 #undef PI
  
+#include "coreneuron/utils/randoms/nrnran123.h"
 #include "coreneuron/nrnoc/md1redef.h"
 #include "coreneuron/nrnconf.h"
 #include "coreneuron/nrnoc/multicore.h"
 #include "coreneuron/nrniv/nrn_acc_manager.h"
-#include "coreneuron/utils/randoms/nrnran123.h"
+#include "coreneuron/mech/cfile/scoplib.h"
 
 #include "coreneuron/nrnoc/md2redef.h"
 #if METHOD3

--- a/test/validation/mod2c_core/c/zoidsyn.c
+++ b/test/validation/mod2c_core/c/zoidsyn.c
@@ -3,14 +3,14 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <math.h>
-#include "coreneuron/mech/cfile/scoplib.h"
 #undef PI
  
+#include "coreneuron/utils/randoms/nrnran123.h"
 #include "coreneuron/nrnoc/md1redef.h"
 #include "coreneuron/nrnconf.h"
 #include "coreneuron/nrnoc/multicore.h"
 #include "coreneuron/nrniv/nrn_acc_manager.h"
-#include "coreneuron/utils/randoms/nrnran123.h"
+#include "coreneuron/mech/cfile/scoplib.h"
 
 #include "coreneuron/nrnoc/md2redef.h"
 #if METHOD3


### PR DESCRIPTION
Random123 header need to be included first for proper
assembly target selection. This commits reorder the
included headers.