### PR TITLE
remove all non necessary extern declarations

### DIFF
--- a/src/mod2c_core/deriv.c
+++ b/src/mod2c_core/deriv.c
@@ -119,7 +119,7 @@ if (deriv_imp_list) {	/* make sure deriv block translation matches method */
 	Sprintf(buf, "static int _deriv%d_advance = 1;\n", listnum);
 	q = linsertstr(procfunc, buf);
 	Sprintf(buf, "\n#define _deriv%d_advance _thread[%d]._i\n\
-#define _dith%d %d\n#define _newtonspace%d _thread[%d]._pvoid\nextern void* nrn_cons_newtonspace(int, int);\n\
+#define _dith%d %d\n#define _newtonspace%d _thread[%d]._pvoid\n\
 ", listnum, thread_data_index, listnum, thread_data_index+1, listnum, thread_data_index+2);
 
 	vectorize_substitute(q, buf);
@@ -187,12 +187,6 @@ method->name, fun->name, suffix, method->name, fun->name,
 suffix, ssprefix, method->name,
 numeqn, listnum, listnum, method->name, fun->name, suffix);
 	vectorize_substitute(qsol, buf);
-	Sprintf(buf,
-	  "\n"
-	  "#pragma acc routine seq\n"
-	  "extern int %s%s_thread(int, int*, int*, int, _threadargsproto_);\n"
-	  , ssprefix, method->name);
-	linsertstr(procfunc, buf);
 
     // euler_thread is defined externally and need a callback function
     // selection of callback is using switch-case implemented in _kinderiv.h
@@ -220,12 +214,6 @@ fun->name, suffix, fun->name, suffix,
 ssprefix, method->name, listnum, numeqn, listnum, listnum, indepsym->name,
 dindepname, fun->name, suffix, listnum);
 	vectorize_substitute(qsol, buf);
-	Sprintf(buf,
-	  "\n"
-	  "#pragma acc routine seq\n"
-	  "extern int %s%s_thread(void*, int, int*, int*, double*, double, int, int, _threadargsproto_);\n"
-	  , ssprefix, method->name);
-	linsertstr(procfunc, buf);
    }
 #endif
 	}

--- a/src/mod2c_core/kinetic.c
+++ b/src/mod2c_core/kinetic.c
@@ -797,12 +797,6 @@ void kinetic_implicit(fun, dt, mname)
 		vectorize_substitute(q, buf);
 		sprintf(buf, "  _nrn_destroy_sparseobj_thread((SparseObj*)_thread[_spth%d]._pvoid);\n", fun->u.i);
 		lappendstr(thread_cleanup_list, buf);
-#if 0
-		Sprintf(buf, "extern void* nrn_cons_sparseobj(int(*)(void*, double*, _threadargsproto_), int, _Memb_list*, _threadargsproto_);\n");
-#else
-		Sprintf(buf, "extern void* nrn_cons_sparseobj(int, int, _Memb_list*, _threadargsproto_);\n");
-#endif
-		linsertstr(procfunc, buf);
 	}
     }	
 	if (rlst->sens_parm) {
@@ -978,15 +972,6 @@ Insertstr(rlst->position, "}");
 #endif
 	{static int first = 1; if (first) {
 		first = 0;
-		Sprintf(buf,"extern double *_getelm();\n");
-		qv = linsertstr(procfunc, buf);
-#if VECTORIZE
-		Sprintf(buf,
-		  "\n#pragma acc routine seq\n"
-		  "extern double *_nrn_thread_getelm(void*, int, int, int);\n"
-		  );
-		vectorize_substitute(qv, buf);
-#endif
 	}}
       }
      }

--- a/src/mod2c_core/nocpout.c
+++ b/src/mod2c_core/nocpout.c
@@ -529,6 +529,22 @@ fprintf(stderr, "Notice: ARTIFICIAL_CELL models that would require thread specif
 		Sprintf(buf, "#define %s %s%s\n", STR(q), STR(q), suffix);
 		Lappendstr(defs_list, buf);
 	}
+
+	Lappendstr(defs_list, "/* external NEURON variables */\n");
+	SYMLISTITER {
+		s = SYM(q);
+		if (s->nrntype & NRNEXTRN) {
+			if (strcmp(s->name, "dt") == 0) { continue; }
+			if (strcmp(s->name, "t") == 0) { continue; }
+			if (strcmp(s->name, "celsius") == 0) {continue;}
+			if (s->subtype & ARRAY) {
+				Sprintf(buf, "extern double* %s;\n", s->name);
+			}else{
+				Sprintf(buf, "extern double %s;\n", s->name);
+			}
+			Lappendstr(defs_list, buf);
+            }
+		}
 	
 #if BBCORE
 	Lappendstr(defs_list, "\n#if 0 /*BBCORE*/\n");

--- a/src/mod2c_core/nocpout.c
+++ b/src/mod2c_core/nocpout.c
@@ -338,17 +338,17 @@ fprintf(stderr, "Notice: ARTIFICIAL_CELL models that would require thread specif
 \n#include \"coreneuron/utils/randoms/nrnran123.h\"\
 \n#include \"coreneuron/nrnoc/md1redef.h\"\
 \n#include \"coreneuron/nrnconf.h\"\
+\n#include \"coreneuron/nrnoc/membfunc.h\"\
 \n#include \"coreneuron/nrnoc/multicore.h\"\
 \n#include \"coreneuron/nrniv/nrn_acc_manager.h\"\
 \n#include \"coreneuron/mech/cfile/scoplib.h\"\n\
+\n#include \"coreneuron/scopmath_core/newton_struct.h\"\
 \n#include \"coreneuron/nrnoc/md2redef.h\"\
-\n#if METHOD3\nextern int _method3;\n#endif\n\
 \n#if !NRNGPU\
 \n#if !defined(DISABLE_HOC_EXP)\
 \n#undef exp\
 \n#define exp hoc_Exp\
 \n#endif\
-\nextern double hoc_Exp(double);\
 \n#endif\n\
 ");
 	if (protect_include_) {
@@ -487,7 +487,6 @@ fprintf(stderr, "Notice: ARTIFICIAL_CELL models that would require thread specif
 	/*SUPPRESS 763*/\n\
 	/*SUPPRESS 765*/\n\
 	");
-	Lappendstr(defs_list, "extern double *getarg();\n");
 #if VECTORIZE
     if (vectorize) {
 	Sprintf(buf, "/* Thread safe. No static _p or _ppvar. */\n");
@@ -530,38 +529,6 @@ fprintf(stderr, "Notice: ARTIFICIAL_CELL models that would require thread specif
 		Sprintf(buf, "#define %s %s%s\n", STR(q), STR(q), suffix);
 		Lappendstr(defs_list, buf);
 	}
-
-	Lappendstr(defs_list, "/* external NEURON variables */\n");
-	SYMLISTITER {
-		s = SYM(q);
-		if (s->nrntype & NRNEXTRN) {
-			if (strcmp(s->name, "dt") == 0) { continue; }
-			if (strcmp(s->name, "t") == 0) { continue; }
-			if (s->subtype & ARRAY) {
-				Sprintf(buf, "extern double* %s;\n", s->name);
-			}else{
-				Sprintf(buf, "extern double %s;\n", s->name);
-			}
-			Lappendstr(defs_list, buf);
-            /* temp fix for PGI compiler where extern variable need copyin definition */
-			if (strcmp(s->name, "celsius") == 0) {
-				Sprintf(buf,
-#if 0
-				"#if defined(PG_ACC_BUGS)\n"
-				"#pragma acc declare copyin(celsius)\n"
-				"#endif\n");
-#else /* work around for weird pg16.3 bug */
-				"#if defined(PG_ACC_BUGS)\n"
-				"#define _celsius_ _celsius_%s\n"
-				"double _celsius_;\n"
-				"#pragma acc declare copyin(_celsius_)\n"
-				"#define celsius _celsius_\n"
-				"#endif\n", suffix);
-#endif
-			    Lappendstr(defs_list, buf);
-            }
-		}
-	}
 	
 #if BBCORE
 	Lappendstr(defs_list, "\n#if 0 /*BBCORE*/\n");
@@ -591,11 +558,6 @@ Sprintf(buf, "static void _hoc_%s(void);\n", s->name);
 		  , suffix);
 		replacstr(q, buf);
 	}
-	Lappendstr(defs_list, "\
-extern int nrn_get_mechtype(const char*);\n\
-extern void hoc_register_prop_size(int, int, int);\n\
-extern Memb_func* memb_func;\n\
-"	);
 
 	/**** create special point process functions */
 	if (point_process) {
@@ -1233,9 +1195,6 @@ Sprintf(buf, "\"%s\", %g,\n", s->name, d1);
 	}
 	if (net_receive_) {
 		Lappendstr(defs_list, "static void _net_receive(Point_process*, int, double);\n");
-		if (for_netcons_) {
-			Lappendstr(defs_list, "extern int _nrn_netcon_args(void*, double***);\n");
-		}
 		if (net_init_q1_) {
 			Lappendstr(defs_list, "static void _net_init(Point_process*, int, double);\n");
 		}
@@ -1255,16 +1214,8 @@ Sprintf(buf, "\"%s\", %g,\n", s->name, d1);
 
 	if (use_bbcorepointer) {
 		lappendstr(defs_list, "static void bbcore_read(double *, int*, int*, int*, _threadargsproto_);\n");
-		lappendstr(defs_list, "extern void hoc_reg_bbcore_read(int, void(*)(double *, int*, int*, int*, _threadargsproto_));\n");
 		lappendstr(defs_list, "static void bbcore_write(double *, int*, int*, int*, _threadargsproto_);\n");
-		lappendstr(defs_list, "extern void hoc_reg_bbcore_write(int, void(*)(double *, int*, int*, int*, _threadargsproto_));\n");
 	}
-	Lappendstr(defs_list, "\
-extern Symbol* hoc_lookup(const char*);\n\
-extern void _nrn_thread_reg(int, int, void(*f)(Datum*));\n\
-extern void _nrn_thread_table_reg(int, void(*)(_threadargsproto_, int));\n\
-extern void _cvode_abstol( Symbol**, double*, int);\n\n\
-");        
 	Sprintf(buf, "void _%s_reg() {\n\
 	int _vectorized = %d;\n", modbase, vectorize);
 	Lappendstr(defs_list, buf);

--- a/src/mod2c_core/parsact.c
+++ b/src/mod2c_core/parsact.c
@@ -1103,7 +1103,6 @@ Fprintf(stderr, "Notice: Use of state_discontinuity in a NET_RECEIVE block is un
 			}
 			if (!state_discon_list_) {
 				state_discon_list_ = newlist();
-				Linsertstr(procfunc, "extern int state_discon_flag_;\n");
 			}
 			lappenditem(state_discon_list_, qpar1->next);
 #endif

--- a/src/mod2c_core/simultan.c
+++ b/src/mod2c_core/simultan.c
@@ -243,6 +243,10 @@ numlist, numlist-1, counts);
 	  , numlist-1, counts, numlist, SYM(q2)->name, suffix, numlist);
 	vectorize_substitute(qret, buf);
 	Insertstr(q3, "/*if(_reset) {abort_run(_reset);}*/ }\n");
+	Sprintf(buf,
+	  "int _newton_%s%s(_threadargsproto_);\n"
+	  , SYM(q2)->name, suffix);
+	Linsertstr(procfunc, buf);
 
 	Sprintf(buf,
 	  "\n"

--- a/src/mod2c_core/simultan.c
+++ b/src/mod2c_core/simultan.c
@@ -243,10 +243,6 @@ numlist, numlist-1, counts);
 	  , numlist-1, counts, numlist, SYM(q2)->name, suffix, numlist);
 	vectorize_substitute(qret, buf);
 	Insertstr(q3, "/*if(_reset) {abort_run(_reset);}*/ }\n");
-	Sprintf(buf,
-	  "extern int _newton_%s%s(_threadargsproto_);\n"
-	  , SYM(q2)->name, suffix);
-	Linsertstr(procfunc, buf);
 
 	Sprintf(buf,
 	  "\n"

--- a/src/mod2c_core/solve.c
+++ b/src/mod2c_core/solve.c
@@ -309,13 +309,11 @@ fprintf(stderr, "Notice: DISCRETE is not thread safe.\n");
 				cvode_interface(fun, listnum, 0);
 				insertstr(qsol, "if (!cvode_active_)");
 				cvode_nrn_cur_solve_ = fun;
-				linsertstr(procfunc, "extern int cvode_active_;\n");
 	}
 	if (cvodemethod_ == 3) { /*cvode_t_v*/
 				cvode_interface(fun, listnum, 0);
 				insertstr(qsol, "if (!cvode_active_)");
 				cvode_nrn_current_solve_ = fun;
-				linsertstr(procfunc, "extern int cvode_active_;\n");
 	}
 #endif
 			}

--- a/test/validation/mod2c_core/c/NaSm.c
+++ b/test/validation/mod2c_core/c/NaSm.c
@@ -133,6 +133,7 @@ extern "C" {
 #endif
  static int hoc_nrnpointerindex =  -1;
  static ThreadDatum* _extcall_thread;
+ /* external NEURON variables */
  
 #if 0 /*BBCORE*/
  /* declaration of user functions */

--- a/test/validation/mod2c_core/c/NaSm.c
+++ b/test/validation/mod2c_core/c/NaSm.c
@@ -8,21 +8,18 @@
 #include "coreneuron/utils/randoms/nrnran123.h"
 #include "coreneuron/nrnoc/md1redef.h"
 #include "coreneuron/nrnconf.h"
+#include "coreneuron/nrnoc/membfunc.h"
 #include "coreneuron/nrnoc/multicore.h"
 #include "coreneuron/nrniv/nrn_acc_manager.h"
 #include "coreneuron/mech/cfile/scoplib.h"
 
+#include "coreneuron/scopmath_core/newton_struct.h"
 #include "coreneuron/nrnoc/md2redef.h"
-#if METHOD3
-extern int _method3;
-#endif
-
 #if !NRNGPU
 #if !defined(DISABLE_HOC_EXP)
 #undef exp
 #define exp hoc_Exp
 #endif
-extern double hoc_Exp(double);
 #endif
  
 #define _thread_present_ /**/ , _slist1[0:1], _dlist1[0:1] 
@@ -95,8 +92,7 @@ extern double hoc_Exp(double);
 	/*SUPPRESS 762*/
 	/*SUPPRESS 763*/
 	/*SUPPRESS 765*/
-	 extern double *getarg();
- /* Thread safe. No static _p or _ppvar. */
+	 /* Thread safe. No static _p or _ppvar. */
  
 #define t _nt->_t
 #define dt _nt->_dt
@@ -137,14 +133,6 @@ extern "C" {
 #endif
  static int hoc_nrnpointerindex =  -1;
  static ThreadDatum* _extcall_thread;
- /* external NEURON variables */
- extern double celsius;
- #if defined(PG_ACC_BUGS)
-#define _celsius_ _celsius__NaSm
-double _celsius_;
-#pragma acc declare copyin(_celsius_)
-#define celsius _celsius_
-#endif
  
 #if 0 /*BBCORE*/
  /* declaration of user functions */
@@ -152,9 +140,6 @@ double _celsius_;
  
 #endif /*BBCORE*/
  static int _mechtype;
- extern int nrn_get_mechtype(const char*);
-extern void hoc_register_prop_size(int, int, int);
-extern Memb_func* memb_func;
  
 #if 0 /*BBCORE*/
  /* connect user functions to hoc names */
@@ -263,11 +248,6 @@ static void nrn_alloc(double* _p, Datum* _ppvar, int _type) {
  
 #define _psize 9
 #define _ppsize 2
- extern Symbol* hoc_lookup(const char*);
-extern void _nrn_thread_reg(int, int, void(*f)(Datum*));
-extern void _nrn_thread_table_reg(int, void(*)(_threadargsproto_, int));
-extern void _cvode_abstol( Symbol**, double*, int);
-
  void _NaSm_reg() {
 	int _vectorized = 1;
   _initlists();

--- a/test/validation/mod2c_core/c/Nap.c
+++ b/test/validation/mod2c_core/c/Nap.c
@@ -80,6 +80,7 @@
 extern "C" {
 #endif
  static int hoc_nrnpointerindex =  -1;
+ /* external NEURON variables */
  
 #if 0 /*BBCORE*/
  /* declaration of user functions */

--- a/test/validation/mod2c_core/c/Nap.c
+++ b/test/validation/mod2c_core/c/Nap.c
@@ -9,21 +9,18 @@
 #include "coreneuron/utils/randoms/nrnran123.h"
 #include "coreneuron/nrnoc/md1redef.h"
 #include "coreneuron/nrnconf.h"
+#include "coreneuron/nrnoc/membfunc.h"
 #include "coreneuron/nrnoc/multicore.h"
 #include "coreneuron/nrniv/nrn_acc_manager.h"
 #include "coreneuron/mech/cfile/scoplib.h"
 
+#include "coreneuron/scopmath_core/newton_struct.h"
 #include "coreneuron/nrnoc/md2redef.h"
-#if METHOD3
-extern int _method3;
-#endif
-
 #if !NRNGPU
 #if !defined(DISABLE_HOC_EXP)
 #undef exp
 #define exp hoc_Exp
 #endif
-extern double hoc_Exp(double);
 #endif
  
 #undef LAYOUT
@@ -51,8 +48,7 @@ extern double hoc_Exp(double);
 	/*SUPPRESS 762*/
 	/*SUPPRESS 763*/
 	/*SUPPRESS 765*/
-	 extern double *getarg();
- static double *_p; static Datum *_ppvar;
+	 static double *_p; static Datum *_ppvar;
  
 #define t nrn_threads->_t
 #define dt nrn_threads->_dt
@@ -84,14 +80,6 @@ extern double hoc_Exp(double);
 extern "C" {
 #endif
  static int hoc_nrnpointerindex =  -1;
- /* external NEURON variables */
- extern double celsius;
- #if defined(PG_ACC_BUGS)
-#define _celsius_ _celsius__nap
-double _celsius_;
-#pragma acc declare copyin(_celsius_)
-#define celsius _celsius_
-#endif
  
 #if 0 /*BBCORE*/
  /* declaration of user functions */
@@ -99,9 +87,6 @@ double _celsius_;
  
 #endif /*BBCORE*/
  static int _mechtype;
- extern int nrn_get_mechtype(const char*);
-extern void hoc_register_prop_size(int, int, int);
-extern Memb_func* memb_func;
  
 #if 0 /*BBCORE*/
  /* connect user functions to hoc names */
@@ -202,11 +187,6 @@ static void nrn_alloc(double* _p, Datum* _ppvar, int _type) {
  
 #define _psize 11
 #define _ppsize 3
- extern Symbol* hoc_lookup(const char*);
-extern void _nrn_thread_reg(int, int, void(*f)(Datum*));
-extern void _nrn_thread_table_reg(int, void(*)(_threadargsproto_, int));
-extern void _cvode_abstol( Symbol**, double*, int);
-
  void _Nap_reg() {
 	int _vectorized = 0;
   _initlists();

--- a/test/validation/mod2c_core/c/NapDA.c
+++ b/test/validation/mod2c_core/c/NapDA.c
@@ -133,6 +133,7 @@ extern "C" {
 #endif
  static int hoc_nrnpointerindex =  -1;
  static ThreadDatum* _extcall_thread;
+ /* external NEURON variables */
  
 #if 0 /*BBCORE*/
  /* declaration of user functions */

--- a/test/validation/mod2c_core/c/NapDA.c
+++ b/test/validation/mod2c_core/c/NapDA.c
@@ -274,6 +274,7 @@ static int _ode_spec1(_threadargsproto_);
 #define INSIDE_NMODL
 #endif
 #include "_kinderiv.h"
+ int _newton_states_NapDA(_threadargsproto_);
  
 #define _slist2 _slist2_NapDA
 int* _slist2;

--- a/test/validation/mod2c_core/c/NapDA.c
+++ b/test/validation/mod2c_core/c/NapDA.c
@@ -8,21 +8,18 @@
 #include "coreneuron/utils/randoms/nrnran123.h"
 #include "coreneuron/nrnoc/md1redef.h"
 #include "coreneuron/nrnconf.h"
+#include "coreneuron/nrnoc/membfunc.h"
 #include "coreneuron/nrnoc/multicore.h"
 #include "coreneuron/nrniv/nrn_acc_manager.h"
 #include "coreneuron/mech/cfile/scoplib.h"
 
+#include "coreneuron/scopmath_core/newton_struct.h"
 #include "coreneuron/nrnoc/md2redef.h"
-#if METHOD3
-extern int _method3;
-#endif
-
 #if !NRNGPU
 #if !defined(DISABLE_HOC_EXP)
 #undef exp
 #define exp hoc_Exp
 #endif
-extern double hoc_Exp(double);
 #endif
  
 #define _thread_present_ /**/ , _thread[0:3] , _slist1[0:2], _dlist1[0:2] , _slist2[0:2] 
@@ -94,8 +91,7 @@ extern double hoc_Exp(double);
 	/*SUPPRESS 762*/
 	/*SUPPRESS 763*/
 	/*SUPPRESS 765*/
-	 extern double *getarg();
- /* Thread safe. No static _p or _ppvar. */
+	 /* Thread safe. No static _p or _ppvar. */
  
 #define t _nt->_t
 #define dt _nt->_dt
@@ -137,7 +133,6 @@ extern "C" {
 #endif
  static int hoc_nrnpointerindex =  -1;
  static ThreadDatum* _extcall_thread;
- /* external NEURON variables */
  
 #if 0 /*BBCORE*/
  /* declaration of user functions */
@@ -148,9 +143,6 @@ extern "C" {
  
 #endif /*BBCORE*/
  static int _mechtype;
- extern int nrn_get_mechtype(const char*);
-extern void hoc_register_prop_size(int, int, int);
-extern Memb_func* memb_func;
  
 #if 0 /*BBCORE*/
  /* connect user functions to hoc names */
@@ -241,11 +233,6 @@ static void nrn_alloc(double* _p, Datum* _ppvar, int _type) {
  
 #define _psize 10
 #define _ppsize 2
- extern Symbol* hoc_lookup(const char*);
-extern void _nrn_thread_reg(int, int, void(*f)(Datum*));
-extern void _nrn_thread_table_reg(int, void(*)(_threadargsproto_, int));
-extern void _cvode_abstol( Symbol**, double*, int);
-
  void _NapDA_reg() {
 	int _vectorized = 1;
   _initlists();
@@ -275,13 +262,9 @@ static int _ninits = 0;
 static int _match_recurse=1;
 static void _modl_cleanup(){ _match_recurse=1;}
  
-#pragma acc routine seq
-extern int derivimplicit_thread(int, int*, int*, int, _threadargsproto_);
- 
 #define _deriv1_advance _thread[0]._i
 #define _dith1 1
 #define _newtonspace1 _thread[2]._pvoid
-extern void* nrn_cons_newtonspace(int, int);
  
 static int _ode_spec1(_threadargsproto_);
 /*static int _ode_matsol1(_threadargsproto_);*/
@@ -291,7 +274,6 @@ static int _ode_spec1(_threadargsproto_);
 #define INSIDE_NMODL
 #endif
 #include "_kinderiv.h"
- extern int _newton_states_NapDA(_threadargsproto_);
  
 #define _slist2 _slist2_NapDA
 int* _slist2;

--- a/test/validation/mod2c_core/c/NapIn.c
+++ b/test/validation/mod2c_core/c/NapIn.c
@@ -79,6 +79,7 @@
 extern "C" {
 #endif
  static int hoc_nrnpointerindex =  -1;
+ /* external NEURON variables */
  
 #if 0 /*BBCORE*/
  /* declaration of user functions */

--- a/test/validation/mod2c_core/c/NapIn.c
+++ b/test/validation/mod2c_core/c/NapIn.c
@@ -9,21 +9,18 @@
 #include "coreneuron/utils/randoms/nrnran123.h"
 #include "coreneuron/nrnoc/md1redef.h"
 #include "coreneuron/nrnconf.h"
+#include "coreneuron/nrnoc/membfunc.h"
 #include "coreneuron/nrnoc/multicore.h"
 #include "coreneuron/nrniv/nrn_acc_manager.h"
 #include "coreneuron/mech/cfile/scoplib.h"
 
+#include "coreneuron/scopmath_core/newton_struct.h"
 #include "coreneuron/nrnoc/md2redef.h"
-#if METHOD3
-extern int _method3;
-#endif
-
 #if !NRNGPU
 #if !defined(DISABLE_HOC_EXP)
 #undef exp
 #define exp hoc_Exp
 #endif
-extern double hoc_Exp(double);
 #endif
  
 #undef LAYOUT
@@ -51,8 +48,7 @@ extern double hoc_Exp(double);
 	/*SUPPRESS 762*/
 	/*SUPPRESS 763*/
 	/*SUPPRESS 765*/
-	 extern double *getarg();
- static double *_p; static Datum *_ppvar;
+	 static double *_p; static Datum *_ppvar;
  
 #define t nrn_threads->_t
 #define dt nrn_threads->_dt
@@ -83,14 +79,6 @@ extern double hoc_Exp(double);
 extern "C" {
 #endif
  static int hoc_nrnpointerindex =  -1;
- /* external NEURON variables */
- extern double celsius;
- #if defined(PG_ACC_BUGS)
-#define _celsius_ _celsius__napIn
-double _celsius_;
-#pragma acc declare copyin(_celsius_)
-#define celsius _celsius_
-#endif
  
 #if 0 /*BBCORE*/
  /* declaration of user functions */
@@ -98,9 +86,6 @@ double _celsius_;
  
 #endif /*BBCORE*/
  static int _mechtype;
- extern int nrn_get_mechtype(const char*);
-extern void hoc_register_prop_size(int, int, int);
-extern Memb_func* memb_func;
  
 #if 0 /*BBCORE*/
  /* connect user functions to hoc names */
@@ -203,11 +188,6 @@ static void nrn_alloc(double* _p, Datum* _ppvar, int _type) {
  
 #define _psize 10
 #define _ppsize 3
- extern Symbol* hoc_lookup(const char*);
-extern void _nrn_thread_reg(int, int, void(*f)(Datum*));
-extern void _nrn_thread_table_reg(int, void(*)(_threadargsproto_, int));
-extern void _cvode_abstol( Symbol**, double*, int);
-
  void _NapIn_reg() {
 	int _vectorized = 0;
   _initlists();

--- a/test/validation/mod2c_core/c/Nap_E.c
+++ b/test/validation/mod2c_core/c/Nap_E.c
@@ -8,21 +8,18 @@
 #include "coreneuron/utils/randoms/nrnran123.h"
 #include "coreneuron/nrnoc/md1redef.h"
 #include "coreneuron/nrnconf.h"
+#include "coreneuron/nrnoc/membfunc.h"
 #include "coreneuron/nrnoc/multicore.h"
 #include "coreneuron/nrniv/nrn_acc_manager.h"
 #include "coreneuron/mech/cfile/scoplib.h"
 
+#include "coreneuron/scopmath_core/newton_struct.h"
 #include "coreneuron/nrnoc/md2redef.h"
-#if METHOD3
-extern int _method3;
-#endif
-
 #if !NRNGPU
 #if !defined(DISABLE_HOC_EXP)
 #undef exp
 #define exp hoc_Exp
 #endif
-extern double hoc_Exp(double);
 #endif
  
 #define _thread_present_ /**/ , _slist1[0:2], _dlist1[0:2] 
@@ -95,8 +92,7 @@ extern double hoc_Exp(double);
 	/*SUPPRESS 762*/
 	/*SUPPRESS 763*/
 	/*SUPPRESS 765*/
-	 extern double *getarg();
- /* Thread safe. No static _p or _ppvar. */
+	 /* Thread safe. No static _p or _ppvar. */
  
 #define t _nt->_t
 #define dt _nt->_dt
@@ -151,7 +147,6 @@ extern "C" {
 #endif
  static int hoc_nrnpointerindex =  -1;
  static ThreadDatum* _extcall_thread;
- /* external NEURON variables */
  
 #if 0 /*BBCORE*/
  /* declaration of user functions */
@@ -159,9 +154,6 @@ extern "C" {
  
 #endif /*BBCORE*/
  static int _mechtype;
- extern int nrn_get_mechtype(const char*);
-extern void hoc_register_prop_size(int, int, int);
-extern Memb_func* memb_func;
  
 #if 0 /*BBCORE*/
  /* connect user functions to hoc names */
@@ -244,11 +236,6 @@ static void nrn_alloc(double* _p, Datum* _ppvar, int _type) {
  
 #define _psize 20
 #define _ppsize 5
- extern Symbol* hoc_lookup(const char*);
-extern void _nrn_thread_reg(int, int, void(*f)(Datum*));
-extern void _nrn_thread_table_reg(int, void(*)(_threadargsproto_, int));
-extern void _cvode_abstol( Symbol**, double*, int);
-
  void _Nap_E_reg() {
 	int _vectorized = 1;
   _initlists();

--- a/test/validation/mod2c_core/c/Nap_E.c
+++ b/test/validation/mod2c_core/c/Nap_E.c
@@ -147,6 +147,7 @@ extern "C" {
 #endif
  static int hoc_nrnpointerindex =  -1;
  static ThreadDatum* _extcall_thread;
+ /* external NEURON variables */
  
 #if 0 /*BBCORE*/
  /* declaration of user functions */

--- a/test/validation/mod2c_core/c/Nap_No.c
+++ b/test/validation/mod2c_core/c/Nap_No.c
@@ -8,21 +8,18 @@
 #include "coreneuron/utils/randoms/nrnran123.h"
 #include "coreneuron/nrnoc/md1redef.h"
 #include "coreneuron/nrnconf.h"
+#include "coreneuron/nrnoc/membfunc.h"
 #include "coreneuron/nrnoc/multicore.h"
 #include "coreneuron/nrniv/nrn_acc_manager.h"
 #include "coreneuron/mech/cfile/scoplib.h"
 
+#include "coreneuron/scopmath_core/newton_struct.h"
 #include "coreneuron/nrnoc/md2redef.h"
-#if METHOD3
-extern int _method3;
-#endif
-
 #if !NRNGPU
 #if !defined(DISABLE_HOC_EXP)
 #undef exp
 #define exp hoc_Exp
 #endif
-extern double hoc_Exp(double);
 #endif
  
 #define _thread_present_ /**/ , _slist1[0:1], _dlist1[0:1] 
@@ -95,8 +92,7 @@ extern double hoc_Exp(double);
 	/*SUPPRESS 762*/
 	/*SUPPRESS 763*/
 	/*SUPPRESS 765*/
-	 extern double *getarg();
- /* Thread safe. No static _p or _ppvar. */
+	 /* Thread safe. No static _p or _ppvar. */
  
 #define t _nt->_t
 #define dt _nt->_dt
@@ -139,7 +135,6 @@ extern "C" {
 #endif
  static int hoc_nrnpointerindex =  -1;
  static ThreadDatum* _extcall_thread;
- /* external NEURON variables */
  
 #if 0 /*BBCORE*/
  /* declaration of user functions */
@@ -148,9 +143,6 @@ extern "C" {
  
 #endif /*BBCORE*/
  static int _mechtype;
- extern int nrn_get_mechtype(const char*);
-extern void hoc_register_prop_size(int, int, int);
-extern Memb_func* memb_func;
  
 #if 0 /*BBCORE*/
  /* connect user functions to hoc names */
@@ -231,11 +223,6 @@ static void nrn_alloc(double* _p, Datum* _ppvar, int _type) {
  
 #define _psize 10
 #define _ppsize 3
- extern Symbol* hoc_lookup(const char*);
-extern void _nrn_thread_reg(int, int, void(*f)(Datum*));
-extern void _nrn_thread_table_reg(int, void(*)(_threadargsproto_, int));
-extern void _cvode_abstol( Symbol**, double*, int);
-
  void _Nap_No_reg() {
 	int _vectorized = 1;
   _initlists();

--- a/test/validation/mod2c_core/c/Nap_No.c
+++ b/test/validation/mod2c_core/c/Nap_No.c
@@ -135,6 +135,7 @@ extern "C" {
 #endif
  static int hoc_nrnpointerindex =  -1;
  static ThreadDatum* _extcall_thread;
+ /* external NEURON variables */
  
 #if 0 /*BBCORE*/
  /* declaration of user functions */

--- a/test/validation/mod2c_core/c/SynNMDA10_1.c
+++ b/test/validation/mod2c_core/c/SynNMDA10_1.c
@@ -117,6 +117,7 @@ static void _net_buf_receive(_NrnThread*);
 extern "C" {
 #endif
  static int hoc_nrnpointerindex =  -1;
+ /* external NEURON variables */
  
 #if 0 /*BBCORE*/
  /* declaration of user functions */

--- a/test/validation/mod2c_core/c/SynNMDA10_1.c
+++ b/test/validation/mod2c_core/c/SynNMDA10_1.c
@@ -9,21 +9,18 @@
 #include "coreneuron/utils/randoms/nrnran123.h"
 #include "coreneuron/nrnoc/md1redef.h"
 #include "coreneuron/nrnconf.h"
+#include "coreneuron/nrnoc/membfunc.h"
 #include "coreneuron/nrnoc/multicore.h"
 #include "coreneuron/nrniv/nrn_acc_manager.h"
 #include "coreneuron/mech/cfile/scoplib.h"
 
+#include "coreneuron/scopmath_core/newton_struct.h"
 #include "coreneuron/nrnoc/md2redef.h"
-#if METHOD3
-extern int _method3;
-#endif
-
 #if !NRNGPU
 #if !defined(DISABLE_HOC_EXP)
 #undef exp
 #define exp hoc_Exp
 #endif
-extern double hoc_Exp(double);
 #endif
  
 #undef LAYOUT
@@ -61,8 +58,7 @@ static void _net_buf_receive(_NrnThread*);
 	/*SUPPRESS 762*/
 	/*SUPPRESS 763*/
 	/*SUPPRESS 765*/
-	 extern double *getarg();
- static double *_p; static Datum *_ppvar;
+	 static double *_p; static Datum *_ppvar;
  
 #define t nrn_threads->_t
 #define dt nrn_threads->_dt
@@ -121,7 +117,6 @@ static void _net_buf_receive(_NrnThread*);
 extern "C" {
 #endif
  static int hoc_nrnpointerindex =  -1;
- /* external NEURON variables */
  
 #if 0 /*BBCORE*/
  /* declaration of user functions */
@@ -129,9 +124,6 @@ extern "C" {
  
 #endif /*BBCORE*/
  static int _mechtype;
- extern int nrn_get_mechtype(const char*);
-extern void hoc_register_prop_size(int, int, int);
-extern Memb_func* memb_func;
  static int _pointtype;
  
 #if 0 /*BBCORE*/
@@ -478,11 +470,6 @@ static void nrn_alloc(double* _p, Datum* _ppvar, int _type) {
  
 #define _psize 40
 #define _ppsize 2
- extern Symbol* hoc_lookup(const char*);
-extern void _nrn_thread_reg(int, int, void(*f)(Datum*));
-extern void _nrn_thread_table_reg(int, void(*)(_threadargsproto_, int));
-extern void _cvode_abstol( Symbol**, double*, int);
-
  void _SynNMDA10_1_reg() {
 	int _vectorized = 0;
   _initlists();
@@ -518,17 +505,12 @@ static int _match_recurse=1;
 static void _modl_cleanup(){ _match_recurse=1;}
 static int release(double);
  
-#pragma acc routine seq
-extern int sparse_thread(void*, int, int*, int*, double*, double, int, int, _threadargsproto_);
- extern double *_getelm();
- 
 #define _MATELM1(_row,_col)	*(_getelm(_row + 1, _col + 1))
  
 #define _RHS1(_arg) _coef1[(_arg + 1)]
  static double *_coef1;
  
 #define _linmat1  1
- extern void* nrn_cons_sparseobj(int, int, _Memb_list*, _threadargsproto_);
  static void* _sparseobj1;
  static void* _cvsparseobj1;
  

--- a/test/validation/mod2c_core/c/SynNMDA10_2.c
+++ b/test/validation/mod2c_core/c/SynNMDA10_2.c
@@ -114,6 +114,7 @@ static void _net_buf_receive(_NrnThread*);
 extern "C" {
 #endif
  static int hoc_nrnpointerindex =  -1;
+ /* external NEURON variables */
  
 #if 0 /*BBCORE*/
  /* declaration of user functions */

--- a/test/validation/mod2c_core/c/SynNMDA10_2.c
+++ b/test/validation/mod2c_core/c/SynNMDA10_2.c
@@ -9,21 +9,18 @@
 #include "coreneuron/utils/randoms/nrnran123.h"
 #include "coreneuron/nrnoc/md1redef.h"
 #include "coreneuron/nrnconf.h"
+#include "coreneuron/nrnoc/membfunc.h"
 #include "coreneuron/nrnoc/multicore.h"
 #include "coreneuron/nrniv/nrn_acc_manager.h"
 #include "coreneuron/mech/cfile/scoplib.h"
 
+#include "coreneuron/scopmath_core/newton_struct.h"
 #include "coreneuron/nrnoc/md2redef.h"
-#if METHOD3
-extern int _method3;
-#endif
-
 #if !NRNGPU
 #if !defined(DISABLE_HOC_EXP)
 #undef exp
 #define exp hoc_Exp
 #endif
-extern double hoc_Exp(double);
 #endif
  
 #undef LAYOUT
@@ -62,8 +59,7 @@ static void _net_buf_receive(_NrnThread*);
 	/*SUPPRESS 762*/
 	/*SUPPRESS 763*/
 	/*SUPPRESS 765*/
-	 extern double *getarg();
- static double *_p; static Datum *_ppvar;
+	 static double *_p; static Datum *_ppvar;
  
 #define t nrn_threads->_t
 #define dt nrn_threads->_dt
@@ -118,7 +114,6 @@ static void _net_buf_receive(_NrnThread*);
 extern "C" {
 #endif
  static int hoc_nrnpointerindex =  -1;
- /* external NEURON variables */
  
 #if 0 /*BBCORE*/
  /* declaration of user functions */
@@ -127,9 +122,6 @@ extern "C" {
  
 #endif /*BBCORE*/
  static int _mechtype;
- extern int nrn_get_mechtype(const char*);
-extern void hoc_register_prop_size(int, int, int);
-extern Memb_func* memb_func;
  static int _pointtype;
  
 #if 0 /*BBCORE*/
@@ -315,11 +307,6 @@ static void nrn_alloc(double* _p, Datum* _ppvar, int _type) {
  
 #define _psize 36
 #define _ppsize 2
- extern Symbol* hoc_lookup(const char*);
-extern void _nrn_thread_reg(int, int, void(*f)(Datum*));
-extern void _nrn_thread_table_reg(int, void(*)(_threadargsproto_, int));
-extern void _cvode_abstol( Symbol**, double*, int);
-
  void _SynNMDA10_2_reg() {
 	int _vectorized = 0;
   _initlists();
@@ -355,7 +342,6 @@ static int _match_recurse=1;
 static void _modl_cleanup(){ _match_recurse=1;}
 static int release(double);
 static int rates(double);
- extern double *_getelm();
  
 #define _MATELM1(_row,_col)	*(_getelm(_row + 1, _col + 1))
  
@@ -363,7 +349,6 @@ static int rates(double);
  static double *_coef1;
  
 #define _linmat1  1
- extern void* nrn_cons_sparseobj(int, int, _Memb_list*, _threadargsproto_);
  static void* _sparseobj1;
  static void* _cvsparseobj1;
  

--- a/test/validation/mod2c_core/c/SynNMDA10_2_2.c
+++ b/test/validation/mod2c_core/c/SynNMDA10_2_2.c
@@ -8,21 +8,18 @@
 #include "coreneuron/utils/randoms/nrnran123.h"
 #include "coreneuron/nrnoc/md1redef.h"
 #include "coreneuron/nrnconf.h"
+#include "coreneuron/nrnoc/membfunc.h"
 #include "coreneuron/nrnoc/multicore.h"
 #include "coreneuron/nrniv/nrn_acc_manager.h"
 #include "coreneuron/mech/cfile/scoplib.h"
 
+#include "coreneuron/scopmath_core/newton_struct.h"
 #include "coreneuron/nrnoc/md2redef.h"
-#if METHOD3
-extern int _method3;
-#endif
-
 #if !NRNGPU
 #if !defined(DISABLE_HOC_EXP)
 #undef exp
 #define exp hoc_Exp
 #endif
-extern double hoc_Exp(double);
 #endif
  
 #define _thread_present_ /**/ , _thread[0:2] , _slist1[0:10], _dlist1[0:10] 
@@ -106,8 +103,7 @@ static void _net_buf_receive(_NrnThread*);
 	/*SUPPRESS 762*/
 	/*SUPPRESS 763*/
 	/*SUPPRESS 765*/
-	 extern double *getarg();
- /* Thread safe. No static _p or _ppvar. */
+	 /* Thread safe. No static _p or _ppvar. */
  
 #define t _nt->_t
 #define dt _nt->_dt
@@ -180,7 +176,6 @@ extern "C" {
 #endif
  static int hoc_nrnpointerindex =  -1;
  static ThreadDatum* _extcall_thread;
- /* external NEURON variables */
  
 #if 0 /*BBCORE*/
  /* declaration of user functions */
@@ -192,9 +187,6 @@ extern "C" {
 #define _mechtype _mechtype_NMDA10_2_2
 int _mechtype;
 #pragma acc declare copyin (_mechtype)
- extern int nrn_get_mechtype(const char*);
-extern void hoc_register_prop_size(int, int, int);
-extern Memb_func* memb_func;
  static int _pointtype;
  
 #if 0 /*BBCORE*/
@@ -367,11 +359,6 @@ static void nrn_alloc(double* _p, Datum* _ppvar, int _type) {
  
 #define _psize 42
 #define _ppsize 3
- extern Symbol* hoc_lookup(const char*);
-extern void _nrn_thread_reg(int, int, void(*f)(Datum*));
-extern void _nrn_thread_table_reg(int, void(*)(_threadargsproto_, int));
-extern void _cvode_abstol( Symbol**, double*, int);
-
  void _SynNMDA10_2_2_reg() {
 	int _vectorized = 1;
   _initlists();
@@ -414,18 +401,11 @@ static void _modl_cleanup(){ _match_recurse=1;}
 static int release(_threadargsprotocomma_ double);
 static int rates(_threadargsprotocomma_ double);
  
-#pragma acc routine seq
-extern int sparse_thread(void*, int, int*, int*, double*, double, int, int, _threadargsproto_);
- 
-#pragma acc routine seq
-extern double *_nrn_thread_getelm(void*, int, int, int);
- 
 #define _MATELM1(_row,_col) _nrn_thread_getelm((SparseObj*)_so, _row + 1, _col + 1, _iml)[_iml]
  
 #define _RHS1(_arg) _rhs[(_arg+1)*_STRIDE]
   
 #define _linmat1  1
- extern void* nrn_cons_sparseobj(int, int, _Memb_list*, _threadargsproto_);
  static int _spth1 = 1;
  static int _cvspth1 = 0;
  

--- a/test/validation/mod2c_core/c/SynNMDA10_2_2.c
+++ b/test/validation/mod2c_core/c/SynNMDA10_2_2.c
@@ -176,6 +176,7 @@ extern "C" {
 #endif
  static int hoc_nrnpointerindex =  -1;
  static ThreadDatum* _extcall_thread;
+ /* external NEURON variables */
  
 #if 0 /*BBCORE*/
  /* declaration of user functions */

--- a/test/validation/mod2c_core/c/SynNMDA16.c
+++ b/test/validation/mod2c_core/c/SynNMDA16.c
@@ -8,21 +8,18 @@
 #include "coreneuron/utils/randoms/nrnran123.h"
 #include "coreneuron/nrnoc/md1redef.h"
 #include "coreneuron/nrnconf.h"
+#include "coreneuron/nrnoc/membfunc.h"
 #include "coreneuron/nrnoc/multicore.h"
 #include "coreneuron/nrniv/nrn_acc_manager.h"
 #include "coreneuron/mech/cfile/scoplib.h"
 
+#include "coreneuron/scopmath_core/newton_struct.h"
 #include "coreneuron/nrnoc/md2redef.h"
-#if METHOD3
-extern int _method3;
-#endif
-
 #if !NRNGPU
 #if !defined(DISABLE_HOC_EXP)
 #undef exp
 #define exp hoc_Exp
 #endif
-extern double hoc_Exp(double);
 #endif
  
 #define _thread_present_ /**/ , _thread[0:3] , _slist1[0:16], _dlist1[0:16] 
@@ -105,8 +102,7 @@ static void _net_buf_receive(_NrnThread*);
 	/*SUPPRESS 762*/
 	/*SUPPRESS 763*/
 	/*SUPPRESS 765*/
-	 extern double *getarg();
- /* Thread safe. No static _p or _ppvar. */
+	 /* Thread safe. No static _p or _ppvar. */
  
 #define t _nt->_t
 #define dt _nt->_dt
@@ -188,7 +184,6 @@ extern "C" {
 #endif
  static int hoc_nrnpointerindex =  -1;
  static ThreadDatum* _extcall_thread;
- /* external NEURON variables */
  
 #if 0 /*BBCORE*/
  /* declaration of user functions */
@@ -196,9 +191,6 @@ extern "C" {
  
 #endif /*BBCORE*/
  static int _mechtype;
- extern int nrn_get_mechtype(const char*);
-extern void hoc_register_prop_size(int, int, int);
-extern Memb_func* memb_func;
  static int _pointtype;
  
 #if 0 /*BBCORE*/
@@ -519,11 +511,6 @@ static void nrn_alloc(double* _p, Datum* _ppvar, int _type) {
  
 #define _psize 50
 #define _ppsize 3
- extern Symbol* hoc_lookup(const char*);
-extern void _nrn_thread_reg(int, int, void(*f)(Datum*));
-extern void _nrn_thread_table_reg(int, void(*)(_threadargsproto_, int));
-extern void _cvode_abstol( Symbol**, double*, int);
-
  void _SynNMDA16_reg() {
 	int _vectorized = 1;
   _initlists();
@@ -566,18 +553,11 @@ static int _match_recurse=1;
 static void _modl_cleanup(){ _match_recurse=1;}
 static int rates(_threadargsprotocomma_ double, double);
  
-#pragma acc routine seq
-extern int sparse_thread(void*, int, int*, int*, double*, double, int, int, _threadargsproto_);
- 
-#pragma acc routine seq
-extern double *_nrn_thread_getelm(void*, int, int, int);
- 
 #define _MATELM1(_row,_col) _nrn_thread_getelm((SparseObj*)_so, _row + 1, _col + 1, _iml)[_iml]
  
 #define _RHS1(_arg) _rhs[(_arg+1)*_STRIDE]
   
 #define _linmat1  1
- extern void* nrn_cons_sparseobj(int, int, _Memb_list*, _threadargsproto_);
  static int _spth1 = 1;
  static int _cvspth1 = 0;
  

--- a/test/validation/mod2c_core/c/SynNMDA16.c
+++ b/test/validation/mod2c_core/c/SynNMDA16.c
@@ -184,6 +184,7 @@ extern "C" {
 #endif
  static int hoc_nrnpointerindex =  -1;
  static ThreadDatum* _extcall_thread;
+ /* external NEURON variables */
  
 #if 0 /*BBCORE*/
  /* declaration of user functions */

--- a/test/validation/mod2c_core/c/SynNMDA16_2.c
+++ b/test/validation/mod2c_core/c/SynNMDA16_2.c
@@ -8,21 +8,18 @@
 #include "coreneuron/utils/randoms/nrnran123.h"
 #include "coreneuron/nrnoc/md1redef.h"
 #include "coreneuron/nrnconf.h"
+#include "coreneuron/nrnoc/membfunc.h"
 #include "coreneuron/nrnoc/multicore.h"
 #include "coreneuron/nrniv/nrn_acc_manager.h"
 #include "coreneuron/mech/cfile/scoplib.h"
 
+#include "coreneuron/scopmath_core/newton_struct.h"
 #include "coreneuron/nrnoc/md2redef.h"
-#if METHOD3
-extern int _method3;
-#endif
-
 #if !NRNGPU
 #if !defined(DISABLE_HOC_EXP)
 #undef exp
 #define exp hoc_Exp
 #endif
-extern double hoc_Exp(double);
 #endif
  
 #define _thread_present_ /**/ , _thread[0:3] , _slist1[0:16], _dlist1[0:16] 
@@ -105,8 +102,7 @@ static void _net_buf_receive(_NrnThread*);
 	/*SUPPRESS 762*/
 	/*SUPPRESS 763*/
 	/*SUPPRESS 765*/
-	 extern double *getarg();
- /* Thread safe. No static _p or _ppvar. */
+	 /* Thread safe. No static _p or _ppvar. */
  
 #define t _nt->_t
 #define dt _nt->_dt
@@ -188,7 +184,6 @@ extern "C" {
 #endif
  static int hoc_nrnpointerindex =  -1;
  static ThreadDatum* _extcall_thread;
- /* external NEURON variables */
  
 #if 0 /*BBCORE*/
  /* declaration of user functions */
@@ -199,9 +194,6 @@ extern "C" {
 #define _mechtype _mechtype_NMDA16_2
 int _mechtype;
 #pragma acc declare copyin (_mechtype)
- extern int nrn_get_mechtype(const char*);
-extern void hoc_register_prop_size(int, int, int);
-extern Memb_func* memb_func;
  static int _pointtype;
  
 #if 0 /*BBCORE*/
@@ -538,11 +530,6 @@ static void nrn_alloc(double* _p, Datum* _ppvar, int _type) {
  
 #define _psize 50
 #define _ppsize 4
- extern Symbol* hoc_lookup(const char*);
-extern void _nrn_thread_reg(int, int, void(*f)(Datum*));
-extern void _nrn_thread_table_reg(int, void(*)(_threadargsproto_, int));
-extern void _cvode_abstol( Symbol**, double*, int);
-
  void _SynNMDA16_2_reg() {
 	int _vectorized = 1;
   _initlists();
@@ -590,18 +577,11 @@ static int _match_recurse=1;
 static void _modl_cleanup(){ _match_recurse=1;}
 static int rates(_threadargsprotocomma_ double, double);
  
-#pragma acc routine seq
-extern int sparse_thread(void*, int, int*, int*, double*, double, int, int, _threadargsproto_);
- 
-#pragma acc routine seq
-extern double *_nrn_thread_getelm(void*, int, int, int);
- 
 #define _MATELM1(_row,_col) _nrn_thread_getelm((SparseObj*)_so, _row + 1, _col + 1, _iml)[_iml]
  
 #define _RHS1(_arg) _rhs[(_arg+1)*_STRIDE]
   
 #define _linmat1  1
- extern void* nrn_cons_sparseobj(int, int, _Memb_list*, _threadargsproto_);
  static int _spth1 = 1;
  static int _cvspth1 = 0;
  

--- a/test/validation/mod2c_core/c/SynNMDA16_2.c
+++ b/test/validation/mod2c_core/c/SynNMDA16_2.c
@@ -184,6 +184,7 @@ extern "C" {
 #endif
  static int hoc_nrnpointerindex =  -1;
  static ThreadDatum* _extcall_thread;
+ /* external NEURON variables */
  
 #if 0 /*BBCORE*/
  /* declaration of user functions */

--- a/test/validation/mod2c_core/c/is.c
+++ b/test/validation/mod2c_core/c/is.c
@@ -313,6 +313,7 @@ static int _ode_spec1(_threadargsproto_);
 #define INSIDE_NMODL
 #endif
 #include "_kinderiv.h"
+ int _newton_states_Is(_threadargsproto_);
  
 #define _slist2 _slist2_Is
 int* _slist2;

--- a/test/validation/mod2c_core/c/is.c
+++ b/test/validation/mod2c_core/c/is.c
@@ -8,21 +8,18 @@
 #include "coreneuron/utils/randoms/nrnran123.h"
 #include "coreneuron/nrnoc/md1redef.h"
 #include "coreneuron/nrnconf.h"
+#include "coreneuron/nrnoc/membfunc.h"
 #include "coreneuron/nrnoc/multicore.h"
 #include "coreneuron/nrniv/nrn_acc_manager.h"
 #include "coreneuron/mech/cfile/scoplib.h"
 
+#include "coreneuron/scopmath_core/newton_struct.h"
 #include "coreneuron/nrnoc/md2redef.h"
-#if METHOD3
-extern int _method3;
-#endif
-
 #if !NRNGPU
 #if !defined(DISABLE_HOC_EXP)
 #undef exp
 #define exp hoc_Exp
 #endif
-extern double hoc_Exp(double);
 #endif
  
 #define _thread_present_ /**/ , _thread[0:4] , _slist1[0:2], _dlist1[0:2] , _slist2[0:2] 
@@ -95,8 +92,7 @@ extern double hoc_Exp(double);
 	/*SUPPRESS 762*/
 	/*SUPPRESS 763*/
 	/*SUPPRESS 765*/
-	 extern double *getarg();
- /* Thread safe. No static _p or _ppvar. */
+	 /* Thread safe. No static _p or _ppvar. */
  
 #define t _nt->_t
 #define dt _nt->_dt
@@ -145,14 +141,6 @@ extern "C" {
 #endif
  static int hoc_nrnpointerindex =  -1;
  static ThreadDatum* _extcall_thread;
- /* external NEURON variables */
- extern double celsius;
- #if defined(PG_ACC_BUGS)
-#define _celsius_ _celsius__Is
-double _celsius_;
-#pragma acc declare copyin(_celsius_)
-#define celsius _celsius_
-#endif
  
 #if 0 /*BBCORE*/
  /* declaration of user functions */
@@ -162,9 +150,6 @@ double _celsius_;
  
 #endif /*BBCORE*/
  static int _mechtype;
- extern int nrn_get_mechtype(const char*);
-extern void hoc_register_prop_size(int, int, int);
-extern Memb_func* memb_func;
  
 #if 0 /*BBCORE*/
  /* connect user functions to hoc names */
@@ -276,11 +261,6 @@ static void nrn_alloc(double* _p, Datum* _ppvar, int _type) {
  
 #define _psize 12
 #define _ppsize 7
- extern Symbol* hoc_lookup(const char*);
-extern void _nrn_thread_reg(int, int, void(*f)(Datum*));
-extern void _nrn_thread_table_reg(int, void(*)(_threadargsproto_, int));
-extern void _cvode_abstol( Symbol**, double*, int);
-
  void _is_reg() {
 	int _vectorized = 1;
   _initlists();
@@ -321,13 +301,9 @@ static int _match_recurse=1;
 static void _modl_cleanup(){ _match_recurse=1;}
 static int rates(_threadargsprotocomma_ double);
  
-#pragma acc routine seq
-extern int derivimplicit_thread(int, int*, int*, int, _threadargsproto_);
- 
 #define _deriv1_advance _thread[0]._i
 #define _dith1 1
 #define _newtonspace1 _thread[2]._pvoid
-extern void* nrn_cons_newtonspace(int, int);
  
 static int _ode_spec1(_threadargsproto_);
 /*static int _ode_matsol1(_threadargsproto_);*/
@@ -337,7 +313,6 @@ static int _ode_spec1(_threadargsproto_);
 #define INSIDE_NMODL
 #endif
 #include "_kinderiv.h"
- extern int _newton_states_Is(_threadargsproto_);
  
 #define _slist2 _slist2_Is
 int* _slist2;

--- a/test/validation/mod2c_core/c/is.c
+++ b/test/validation/mod2c_core/c/is.c
@@ -141,6 +141,7 @@ extern "C" {
 #endif
  static int hoc_nrnpointerindex =  -1;
  static ThreadDatum* _extcall_thread;
+ /* external NEURON variables */
  
 #if 0 /*BBCORE*/
  /* declaration of user functions */

--- a/test/validation/mod2c_core/c/zoidsyn.c
+++ b/test/validation/mod2c_core/c/zoidsyn.c
@@ -8,21 +8,18 @@
 #include "coreneuron/utils/randoms/nrnran123.h"
 #include "coreneuron/nrnoc/md1redef.h"
 #include "coreneuron/nrnconf.h"
+#include "coreneuron/nrnoc/membfunc.h"
 #include "coreneuron/nrnoc/multicore.h"
 #include "coreneuron/nrniv/nrn_acc_manager.h"
 #include "coreneuron/mech/cfile/scoplib.h"
 
+#include "coreneuron/scopmath_core/newton_struct.h"
 #include "coreneuron/nrnoc/md2redef.h"
-#if METHOD3
-extern int _method3;
-#endif
-
 #if !NRNGPU
 #if !defined(DISABLE_HOC_EXP)
 #undef exp
 #define exp hoc_Exp
 #endif
-extern double hoc_Exp(double);
 #endif
  
 #define _thread_present_ /**/ 
@@ -103,8 +100,7 @@ static void _net_buf_receive(_NrnThread*);
 	/*SUPPRESS 762*/
 	/*SUPPRESS 763*/
 	/*SUPPRESS 765*/
-	 extern double *getarg();
- /* Thread safe. No static _p or _ppvar. */
+	 /* Thread safe. No static _p or _ppvar. */
  
 #define t _nt->_t
 #define dt _nt->_dt
@@ -153,7 +149,6 @@ extern "C" {
 #endif
  static int hoc_nrnpointerindex =  -1;
  static ThreadDatum* _extcall_thread;
- /* external NEURON variables */
  
 #if 0 /*BBCORE*/
  /* declaration of user functions */
@@ -163,9 +158,6 @@ extern "C" {
 #define _mechtype _mechtype_ZoidSyn
 int _mechtype;
 #pragma acc declare copyin (_mechtype)
- extern int nrn_get_mechtype(const char*);
-extern void hoc_register_prop_size(int, int, int);
-extern Memb_func* memb_func;
  static int _pointtype;
  
 #if 0 /*BBCORE*/
@@ -291,11 +283,6 @@ static void nrn_alloc(double* _p, Datum* _ppvar, int _type) {
  
 #define _psize 18
 #define _ppsize 3
- extern Symbol* hoc_lookup(const char*);
-extern void _nrn_thread_reg(int, int, void(*f)(Datum*));
-extern void _nrn_thread_table_reg(int, void(*)(_threadargsproto_, int));
-extern void _cvode_abstol( Symbol**, double*, int);
-
  void _zoidsyn_reg() {
 	int _vectorized = 1;
   _initlists();

--- a/test/validation/mod2c_core/c/zoidsyn.c
+++ b/test/validation/mod2c_core/c/zoidsyn.c
@@ -149,6 +149,7 @@ extern "C" {
 #endif
  static int hoc_nrnpointerindex =  -1;
  static ThreadDatum* _extcall_thread;
+ /* external NEURON variables */
  
 #if 0 /*BBCORE*/
  /* declaration of user functions */


### PR DESCRIPTION
A lot of extern declarations that potentially conflict with what is delcared in coreneuron. We remove them and add the fitting coreneuron headers instead. 
Using this way, declarations are all centralized in one place.