### PR TITLE
Avoid macro redefinition warnings: coreneuron's mech/mod2c_core_thread.h

### DIFF
--- a/src/mod2c_core/nocpout.c
+++ b/src/mod2c_core/nocpout.c
@@ -466,6 +466,12 @@ fprintf(stderr, "Notice: ARTIFICIAL_CELL models that would require thread specif
 	Lappendstr(defs_list, "\n");
 #endif /* distinct names for easier profiling */
 
+	Lappendstr(defs_list, "\n\
+#undef _threadargscomma_\n\
+#undef _threadargsprotocomma_\n\
+#undef _threadargs_\n\
+#undef _threadargsproto_\n\
+");
 	if (vectorize) {
 		Lappendstr(defs_list, "\n\
 #define _threadargscomma_ _iml, _cntml_padded, _p, _ppvar, _thread, _nt, v,\n\

--- a/test/validation/mod2c_core/c/NaSm.c
+++ b/test/validation/mod2c_core/c/NaSm.c
@@ -84,6 +84,11 @@
 #define rates rates_NaSm 
 #define states states_NaSm 
  
+#undef _threadargscomma_
+#undef _threadargsprotocomma_
+#undef _threadargs_
+#undef _threadargsproto_
+ 
 #define _threadargscomma_ _iml, _cntml_padded, _p, _ppvar, _thread, _nt, v,
 #define _threadargsprotocomma_ int _iml, int _cntml_padded, double* _p, Datum* _ppvar, ThreadDatum* _thread, _NrnThread* _nt, double v,
 #define _threadargs_ _iml, _cntml_padded, _p, _ppvar, _thread, _nt, v

--- a/test/validation/mod2c_core/c/Nap.c
+++ b/test/validation/mod2c_core/c/Nap.c
@@ -40,6 +40,11 @@
 #define states states_nap 
 #define trates trates_nap 
  
+#undef _threadargscomma_
+#undef _threadargsprotocomma_
+#undef _threadargs_
+#undef _threadargsproto_
+ 
 #define _threadargscomma_ /**/
 #define _threadargsprotocomma_ /**/
 #define _threadargs_ /**/

--- a/test/validation/mod2c_core/c/NapDA.c
+++ b/test/validation/mod2c_core/c/NapDA.c
@@ -83,6 +83,11 @@
 #define nrn_jacob_launcher nrn_jacob_NapDA_launcher 
 #define states states_NapDA 
  
+#undef _threadargscomma_
+#undef _threadargsprotocomma_
+#undef _threadargs_
+#undef _threadargsproto_
+ 
 #define _threadargscomma_ _iml, _cntml_padded, _p, _ppvar, _thread, _nt, v,
 #define _threadargsprotocomma_ int _iml, int _cntml_padded, double* _p, Datum* _ppvar, ThreadDatum* _thread, _NrnThread* _nt, double v,
 #define _threadargs_ _iml, _cntml_padded, _p, _ppvar, _thread, _nt, v

--- a/test/validation/mod2c_core/c/NapIn.c
+++ b/test/validation/mod2c_core/c/NapIn.c
@@ -40,6 +40,11 @@
 #define states states_napIn 
 #define trates trates_napIn 
  
+#undef _threadargscomma_
+#undef _threadargsprotocomma_
+#undef _threadargs_
+#undef _threadargsproto_
+ 
 #define _threadargscomma_ /**/
 #define _threadargsprotocomma_ /**/
 #define _threadargs_ /**/

--- a/test/validation/mod2c_core/c/Nap_E.c
+++ b/test/validation/mod2c_core/c/Nap_E.c
@@ -84,6 +84,11 @@
 #define rates rates_Nap_E 
 #define states states_Nap_E 
  
+#undef _threadargscomma_
+#undef _threadargsprotocomma_
+#undef _threadargs_
+#undef _threadargsproto_
+ 
 #define _threadargscomma_ _iml, _cntml_padded, _p, _ppvar, _thread, _nt, v,
 #define _threadargsprotocomma_ int _iml, int _cntml_padded, double* _p, Datum* _ppvar, ThreadDatum* _thread, _NrnThread* _nt, double v,
 #define _threadargs_ _iml, _cntml_padded, _p, _ppvar, _thread, _nt, v

--- a/test/validation/mod2c_core/c/Nap_No.c
+++ b/test/validation/mod2c_core/c/Nap_No.c
@@ -84,6 +84,11 @@
 #define rates rates_Nap_No 
 #define states states_Nap_No 
  
+#undef _threadargscomma_
+#undef _threadargsprotocomma_
+#undef _threadargs_
+#undef _threadargsproto_
+ 
 #define _threadargscomma_ _iml, _cntml_padded, _p, _ppvar, _thread, _nt, v,
 #define _threadargsprotocomma_ int _iml, int _cntml_padded, double* _p, Datum* _ppvar, ThreadDatum* _thread, _NrnThread* _nt, double v,
 #define _threadargs_ _iml, _cntml_padded, _p, _ppvar, _thread, _nt, v

--- a/test/validation/mod2c_core/c/SynNMDA10_1.c
+++ b/test/validation/mod2c_core/c/SynNMDA10_1.c
@@ -50,6 +50,11 @@ static void _net_buf_receive(_NrnThread*);
 #define kstates kstates_NMDA10_1 
 #define release release_NMDA10_1 
  
+#undef _threadargscomma_
+#undef _threadargsprotocomma_
+#undef _threadargs_
+#undef _threadargsproto_
+ 
 #define _threadargscomma_ /**/
 #define _threadargsprotocomma_ /**/
 #define _threadargs_ /**/

--- a/test/validation/mod2c_core/c/SynNMDA10_2.c
+++ b/test/validation/mod2c_core/c/SynNMDA10_2.c
@@ -51,6 +51,11 @@ static void _net_buf_receive(_NrnThread*);
 #define release release_NMDA10_2 
 #define rates rates_NMDA10_2 
  
+#undef _threadargscomma_
+#undef _threadargsprotocomma_
+#undef _threadargs_
+#undef _threadargsproto_
+ 
 #define _threadargscomma_ /**/
 #define _threadargsprotocomma_ /**/
 #define _threadargs_ /**/

--- a/test/validation/mod2c_core/c/SynNMDA10_2_2.c
+++ b/test/validation/mod2c_core/c/SynNMDA10_2_2.c
@@ -95,6 +95,11 @@ static void _net_buf_receive(_NrnThread*);
 #define release release_NMDA10_2_2 
 #define rates rates_NMDA10_2_2 
  
+#undef _threadargscomma_
+#undef _threadargsprotocomma_
+#undef _threadargs_
+#undef _threadargsproto_
+ 
 #define _threadargscomma_ _iml, _cntml_padded, _p, _ppvar, _thread, _nt, v,
 #define _threadargsprotocomma_ int _iml, int _cntml_padded, double* _p, Datum* _ppvar, ThreadDatum* _thread, _NrnThread* _nt, double v,
 #define _threadargs_ _iml, _cntml_padded, _p, _ppvar, _thread, _nt, v

--- a/test/validation/mod2c_core/c/SynNMDA16.c
+++ b/test/validation/mod2c_core/c/SynNMDA16.c
@@ -94,6 +94,11 @@ static void _net_buf_receive(_NrnThread*);
 #define kstates kstates_NMDA16 
 #define rates rates_NMDA16 
  
+#undef _threadargscomma_
+#undef _threadargsprotocomma_
+#undef _threadargs_
+#undef _threadargsproto_
+ 
 #define _threadargscomma_ _iml, _cntml_padded, _p, _ppvar, _thread, _nt, v,
 #define _threadargsprotocomma_ int _iml, int _cntml_padded, double* _p, Datum* _ppvar, ThreadDatum* _thread, _NrnThread* _nt, double v,
 #define _threadargs_ _iml, _cntml_padded, _p, _ppvar, _thread, _nt, v

--- a/test/validation/mod2c_core/c/SynNMDA16_2.c
+++ b/test/validation/mod2c_core/c/SynNMDA16_2.c
@@ -94,6 +94,11 @@ static void _net_buf_receive(_NrnThread*);
 #define kstates kstates_NMDA16_2 
 #define rates rates_NMDA16_2 
  
+#undef _threadargscomma_
+#undef _threadargsprotocomma_
+#undef _threadargs_
+#undef _threadargsproto_
+ 
 #define _threadargscomma_ _iml, _cntml_padded, _p, _ppvar, _thread, _nt, v,
 #define _threadargsprotocomma_ int _iml, int _cntml_padded, double* _p, Datum* _ppvar, ThreadDatum* _thread, _NrnThread* _nt, double v,
 #define _threadargs_ _iml, _cntml_padded, _p, _ppvar, _thread, _nt, v

--- a/test/validation/mod2c_core/c/is.c
+++ b/test/validation/mod2c_core/c/is.c
@@ -84,6 +84,11 @@
 #define rates rates_Is 
 #define states states_Is 
  
+#undef _threadargscomma_
+#undef _threadargsprotocomma_
+#undef _threadargs_
+#undef _threadargsproto_
+ 
 #define _threadargscomma_ _iml, _cntml_padded, _p, _ppvar, _thread, _nt, v,
 #define _threadargsprotocomma_ int _iml, int _cntml_padded, double* _p, Datum* _ppvar, ThreadDatum* _thread, _NrnThread* _nt, double v,
 #define _threadargs_ _iml, _cntml_padded, _p, _ppvar, _thread, _nt, v

--- a/test/validation/mod2c_core/c/zoidsyn.c
+++ b/test/validation/mod2c_core/c/zoidsyn.c
@@ -92,6 +92,11 @@ static void _net_buf_receive(_NrnThread*);
 #endif
  
  
+#undef _threadargscomma_
+#undef _threadargsprotocomma_
+#undef _threadargs_
+#undef _threadargsproto_
+ 
 #define _threadargscomma_ _iml, _cntml_padded, _p, _ppvar, _thread, _nt, v,
 #define _threadargsprotocomma_ int _iml, int _cntml_padded, double* _p, Datum* _ppvar, ThreadDatum* _thread, _NrnThread* _nt, double v,
 #define _threadargs_ _iml, _cntml_padded, _p, _ppvar, _thread, _nt, v


### PR DESCRIPTION
has macro definitions without "_" i.e. without use of md1redef.h. When this
headers get included, it results into macro redefinition warning.

Undef all relevant macros in mod2c.