### PR TITLE
Fix PGI and OpenACC issues with latest CoreNEURON master with C++

### DIFF
--- a/src/mod2c_core/noccout.c
+++ b/src/mod2c_core/noccout.c
@@ -784,21 +784,11 @@ void c_out_vectorize()
 	   is 0 when an non file function, e.g. derivimplicit_thread,
 	   is called which calls back into the mod file. But the problem
 	   does not seem to impact other global variable defined in the
-	   mod file
+	   mod file.
+       With c++ files we declare routine seq in which case static variables
+       can't be used. So, introducing _celsius_ as default implementation.
 	*/
-        P("\n#if defined(PG_ACC_BUGS)\n");
-#if 0
-        P("#pragma acc update device (celsius) if(_nt->compute_gpu)\n");
-#else /* work around a weird pg16.3 bug */
-	P("#if defined(celsius)\n");
-	P("#undef celsius;\n");
-	P("_celsius_ = celsius;\n");
-        P("#pragma acc update device (_celsius_) if(_nt->compute_gpu)\n");
-	P("#define celsius _celsius_\n");
-	P("#endif\n");
-#endif
-        P("#endif\n");
-	P("_ACC_GLOBALS_UPDATE_\n");
+	P("_acc_globals_update();\n");
 
 	 pr_layout_for_p(1, NRN_INIT);
 

--- a/src/mod2c_core/nocpout.c
+++ b/src/mod2c_core/nocpout.c
@@ -660,6 +660,9 @@ Sprintf(buf, "\"%s%s\", _hoc_%s,\n", s->name, rsuffix, s->name);
 		int j;
 		s = SYM(q);
 		if ((s->subtype & FUNCT)) {
+            if(!artificial_cell) {
+                Lappendstr(defs_list, "#pragma acc routine seq\n");
+            }
 			Sprintf(buf, "inline double %s(", s->name);
 			Lappendstr(defs_list, buf);
 			if (vectorize && !s->no_threadargs) {
@@ -844,9 +847,13 @@ diag("No statics allowed for thread safe models:", s->name);
 #endif
 			decode_ustr(s, &d1, &d2, buf);
 			if (s->subtype & ARRAY) {
-				Sprintf(buf, "static double %s[%d];\n", s->name, s->araydim);
+				Sprintf(buf, "static double %s[%d];\n"
+                             "#pragma acc declare create(%s)\n",
+                             s->name, s->araydim, s->name);
 			}else{
-				Sprintf(buf, "static double %s = %g;\n", s->name, d1);
+				Sprintf(buf, "static double %s = %g;\n"
+                             "#pragma acc declare copyin(%s)\n",
+                             s->name, d1, s->name);
 			}
 			Lappendstr(defs_list, buf);
 		}

--- a/src/mod2c_core/nocpout.c
+++ b/src/mod2c_core/nocpout.c
@@ -819,11 +819,10 @@ s->name, suffix, gind, s->name, gind);
             Lappendstr(defs_list, "#pragma acc update device(_celsius_)\n");
         }
 		Lappendstr(defs_list, "}\n\n");
-        Lappendstr(defs_list, "\n");
 	}
 
     if (use_celsius) {
-        Lappendstr(defs_list, "\n#define celsius _celsius_\n");
+        Lappendstr(defs_list, "#define celsius _celsius_\n");
     }
 
 	Lappendstr(defs_list, "\n#if 0 /*BBCORE*/\n");

--- a/src/mod2c_core/nocpout.c
+++ b/src/mod2c_core/nocpout.c
@@ -200,7 +200,7 @@ int artificial_cell; /* 1 if also explicitly declared an ARTIFICIAL_CELL */
 static int diamdec = 0;	/*1 if diam is declared*/
 static int areadec = 0;
 static int use_bbcorepointer = 0;
-
+static int use_celsius = 0; /* celsius is used */
 static void defs_h();
 static int iontype();
 static void nrndeclare();
@@ -381,14 +381,12 @@ fprintf(stderr, "Notice: ARTIFICIAL_CELL models that would require thread specif
 \n#define _PRAGMA_FOR_CUR_ACC_LOOP_ _Pragma(\"acc parallel loop present(_ni[0:_cntml_actual], _nt_data[0:_nt->_ndata], _p[0:_cntml_padded*_psize], _ppvar[0:_cntml_padded*_ppsize], _vec_v[0:_nt->end], _vec_d[0:_nt->end], _vec_rhs[0:_nt->end], _nt[0:1] _thread_present_) if(_nt->compute_gpu) async(stream_id)\")\
 \n#define _PRAGMA_FOR_CUR_SYN_ACC_LOOP_ _Pragma(\"acc parallel loop present(_ni[0:_cntml_actual], _nt_data[0:_nt->_ndata], _p[0:_cntml_padded*_psize], _ppvar[0:_cntml_padded*_ppsize], _vec_v[0:_nt->end], _vec_shadow_rhs[0:_nt->shadow_rhs_cnt], _vec_shadow_d[0:_nt->shadow_rhs_cnt], _vec_d[0:_nt->end], _vec_rhs[0:_nt->end], _nt[0:1]) if(_nt->compute_gpu) async(stream_id)\")\
 \n#define _PRAGMA_FOR_NETRECV_ACC_LOOP_ _Pragma(\"acc parallel loop present(_pnt[0:_pnt_length], _nrb[0:1], _nt[0:1], nrn_threads[0:nrn_nthread]) if(_nt->compute_gpu) async(stream_id)\")\
-\n#define _ACC_GLOBALS_UPDATE_ if (_nt->compute_gpu) {_acc_globals_update();}\
 \n#else\
 \n#define _PRAGMA_FOR_INIT_ACC_LOOP_ _Pragma(\"\")\
 \n#define _PRAGMA_FOR_STATE_ACC_LOOP_ _Pragma(\"\")\
 \n#define _PRAGMA_FOR_CUR_ACC_LOOP_ _Pragma(\"\")\
 \n#define _PRAGMA_FOR_CUR_SYN_ACC_LOOP_ _Pragma(\"\")\
 \n#define _PRAGMA_FOR_NETRECV_ACC_LOOP_ _Pragma(\"\")\
-\n#define _ACC_GLOBALS_UPDATE_ ;\
 \n#endif\
 \n \
 \n#if defined(__clang__)\
@@ -553,15 +551,22 @@ fprintf(stderr, "Notice: ARTIFICIAL_CELL models that would require thread specif
 		if (s->nrntype & NRNEXTRN) {
 			if (strcmp(s->name, "dt") == 0) { continue; }
 			if (strcmp(s->name, "t") == 0) { continue; }
-			if (strcmp(s->name, "celsius") == 0) {continue;}
 			if (s->subtype & ARRAY) {
 				Sprintf(buf, "extern double* %s;\n", s->name);
 			}else{
 				Sprintf(buf, "extern double %s;\n", s->name);
 			}
 			Lappendstr(defs_list, buf);
+			if (strcmp(s->name, "celsius") == 0) {
+                use_celsius = 1;
+                Sprintf(buf,
+                "#define _celsius_ _celsius_%s\n"
+                "double _celsius_;\n"
+                "#pragma acc declare copyin(_celsius_)\n", suffix);
+                Lappendstr(defs_list, buf);
             }
-		}
+        }
+    }
 	
 #if BBCORE
 	Lappendstr(defs_list, "\n#if 0 /*BBCORE*/\n");
@@ -809,8 +814,17 @@ s->name, suffix, gind, s->name, gind);
 		if (acc_globals_update_list->next != acc_globals_update_list) {
 			movelist(acc_globals_update_list->next, acc_globals_update_list->prev, defs_list);
 		}
-		Lappendstr(defs_list, "}\n");
+        if (use_celsius) {
+            Lappendstr(defs_list, "_celsius_ = celsius;\n");
+            Lappendstr(defs_list, "#pragma acc update device(_celsius_)\n");
+        }
+		Lappendstr(defs_list, "}\n\n");
+        Lappendstr(defs_list, "\n");
 	}
+
+    if (use_celsius) {
+        Lappendstr(defs_list, "\n#define celsius _celsius_\n");
+    }
 
 	Lappendstr(defs_list, "\n#if 0 /*BBCORE*/\n");
 #endif

--- a/test/validation/mod2c_core/cpp/NaSm.cpp
+++ b/test/validation/mod2c_core/cpp/NaSm.cpp
@@ -40,14 +40,12 @@
 #define _PRAGMA_FOR_CUR_ACC_LOOP_ _Pragma("acc parallel loop present(_ni[0:_cntml_actual], _nt_data[0:_nt->_ndata], _p[0:_cntml_padded*_psize], _ppvar[0:_cntml_padded*_ppsize], _vec_v[0:_nt->end], _vec_d[0:_nt->end], _vec_rhs[0:_nt->end], _nt[0:1] _thread_present_) if(_nt->compute_gpu) async(stream_id)")
 #define _PRAGMA_FOR_CUR_SYN_ACC_LOOP_ _Pragma("acc parallel loop present(_ni[0:_cntml_actual], _nt_data[0:_nt->_ndata], _p[0:_cntml_padded*_psize], _ppvar[0:_cntml_padded*_ppsize], _vec_v[0:_nt->end], _vec_shadow_rhs[0:_nt->shadow_rhs_cnt], _vec_shadow_d[0:_nt->shadow_rhs_cnt], _vec_d[0:_nt->end], _vec_rhs[0:_nt->end], _nt[0:1]) if(_nt->compute_gpu) async(stream_id)")
 #define _PRAGMA_FOR_NETRECV_ACC_LOOP_ _Pragma("acc parallel loop present(_pnt[0:_pnt_length], _nrb[0:1], _nt[0:1], nrn_threads[0:nrn_nthread]) if(_nt->compute_gpu) async(stream_id)")
-#define _ACC_GLOBALS_UPDATE_ if (_nt->compute_gpu) {_acc_globals_update();}
 #else
 #define _PRAGMA_FOR_INIT_ACC_LOOP_ _Pragma("")
 #define _PRAGMA_FOR_STATE_ACC_LOOP_ _Pragma("")
 #define _PRAGMA_FOR_CUR_ACC_LOOP_ _Pragma("")
 #define _PRAGMA_FOR_CUR_SYN_ACC_LOOP_ _Pragma("")
 #define _PRAGMA_FOR_NETRECV_ACC_LOOP_ _Pragma("")
-#define _ACC_GLOBALS_UPDATE_ ;
 #endif
  
 #if defined(__clang__)
@@ -140,6 +138,10 @@
  static int hoc_nrnpointerindex =  -1;
  static ThreadDatum* _extcall_thread;
  /* external NEURON variables */
+ extern double celsius;
+ #define _celsius_ _celsius__NaSm
+double _celsius_;
+#pragma acc declare copyin(_celsius_)
  
 #if 0 /*BBCORE*/
  /* declaration of user functions */
@@ -188,7 +190,11 @@ static void _acc_globals_update() {
  #pragma acc update device (ktm) if(nrn_threads->compute_gpu)
  #pragma acc update device (ksm) if(nrn_threads->compute_gpu)
  #pragma acc update device (tom) if(nrn_threads->compute_gpu)
+ _celsius_ = celsius;
+ #pragma acc update device(_celsius_)
  }
+
+ #define celsius _celsius_
  
 #if 0 /*BBCORE*/
  /* some parameters have upper and lower limits */
@@ -203,7 +209,9 @@ static void _acc_globals_update() {
  
 #endif /*BBCORE*/
  static double delta_t = 1;
+#pragma acc declare copyin(delta_t)
  static double m0 = 0;
+#pragma acc declare copyin(m0)
  /* connect global user variables to hoc */
  static DoubScal hoc_scdoub[] = {
  "ena_NaSm", &ena_NaSm,
@@ -356,16 +364,7 @@ double _v, v; int* _ni; int _iml, _cntml_padded, _cntml_actual;
 _cntml_actual = _ml->_nodecount;
 _cntml_padded = _ml->_nodecount_padded;
 _thread = _ml->_thread;
-
-#if defined(PG_ACC_BUGS)
-#if defined(celsius)
-#undef celsius;
-_celsius_ = celsius;
-#pragma acc update device (_celsius_) if(_nt->compute_gpu)
-#define celsius _celsius_
-#endif
-#endif
-_ACC_GLOBALS_UPDATE_
+_acc_globals_update();
 double * _nt_data = _nt->_data;
 double * _vec_v = _nt->_actual_v;
 int stream_id = _nt->stream_id;

--- a/test/validation/mod2c_core/cpp/Nap.cpp
+++ b/test/validation/mod2c_core/cpp/Nap.cpp
@@ -87,6 +87,10 @@
 #endif
  static int hoc_nrnpointerindex =  -1;
  /* external NEURON variables */
+ extern double celsius;
+ #define _celsius_ _celsius__nap
+double _celsius_;
+#pragma acc declare copyin(_celsius_)
  
 #if 0 /*BBCORE*/
  /* declaration of user functions */
@@ -119,7 +123,11 @@ static void _acc_globals_update() {
  #pragma acc update device (eNa) if(nrn_threads->compute_gpu)
  #pragma acc update device (mtau) if(nrn_threads->compute_gpu)
  #pragma acc update device (minf) if(nrn_threads->compute_gpu)
+ _celsius_ = celsius;
+ #pragma acc update device(_celsius_)
  }
+
+ #define celsius _celsius_
  
 #if 0 /*BBCORE*/
  /* some parameters have upper and lower limits */
@@ -136,8 +144,11 @@ static void _acc_globals_update() {
  
 #endif /*BBCORE*/
  static double delta_t = 0.01;
+#pragma acc declare copyin(delta_t)
  static double m0 = 0;
+#pragma acc declare copyin(m0)
  static double v = 0;
+#pragma acc declare copyin(v)
  /* connect global user variables to hoc */
  static DoubScal hoc_scdoub[] = {
  "eNa_nap", &eNa_nap,

--- a/test/validation/mod2c_core/cpp/NapDA.cpp
+++ b/test/validation/mod2c_core/cpp/NapDA.cpp
@@ -40,14 +40,12 @@
 #define _PRAGMA_FOR_CUR_ACC_LOOP_ _Pragma("acc parallel loop present(_ni[0:_cntml_actual], _nt_data[0:_nt->_ndata], _p[0:_cntml_padded*_psize], _ppvar[0:_cntml_padded*_ppsize], _vec_v[0:_nt->end], _vec_d[0:_nt->end], _vec_rhs[0:_nt->end], _nt[0:1] _thread_present_) if(_nt->compute_gpu) async(stream_id)")
 #define _PRAGMA_FOR_CUR_SYN_ACC_LOOP_ _Pragma("acc parallel loop present(_ni[0:_cntml_actual], _nt_data[0:_nt->_ndata], _p[0:_cntml_padded*_psize], _ppvar[0:_cntml_padded*_ppsize], _vec_v[0:_nt->end], _vec_shadow_rhs[0:_nt->shadow_rhs_cnt], _vec_shadow_d[0:_nt->shadow_rhs_cnt], _vec_d[0:_nt->end], _vec_rhs[0:_nt->end], _nt[0:1]) if(_nt->compute_gpu) async(stream_id)")
 #define _PRAGMA_FOR_NETRECV_ACC_LOOP_ _Pragma("acc parallel loop present(_pnt[0:_pnt_length], _nrb[0:1], _nt[0:1], nrn_threads[0:nrn_nthread]) if(_nt->compute_gpu) async(stream_id)")
-#define _ACC_GLOBALS_UPDATE_ if (_nt->compute_gpu) {_acc_globals_update();}
 #else
 #define _PRAGMA_FOR_INIT_ACC_LOOP_ _Pragma("")
 #define _PRAGMA_FOR_STATE_ACC_LOOP_ _Pragma("")
 #define _PRAGMA_FOR_CUR_ACC_LOOP_ _Pragma("")
 #define _PRAGMA_FOR_CUR_SYN_ACC_LOOP_ _Pragma("")
 #define _PRAGMA_FOR_NETRECV_ACC_LOOP_ _Pragma("")
-#define _ACC_GLOBALS_UPDATE_ ;
 #endif
  
 #if defined(__clang__)
@@ -167,14 +165,19 @@
 #define half half_NapDA
 #define mbet mbet_NapDA
 #define malf malf_NapDA
+ #pragma acc routine seq
  inline double hbet( _threadargsprotocomma_ double );
+ #pragma acc routine seq
  inline double half( _threadargsprotocomma_ double );
+ #pragma acc routine seq
  inline double mbet( _threadargsprotocomma_ double );
+ #pragma acc routine seq
  inline double malf( _threadargsprotocomma_ double );
  /* declare global and static user variables */
  
 static void _acc_globals_update() {
  }
+
  
 #if 0 /*BBCORE*/
  /* some parameters have upper and lower limits */
@@ -191,8 +194,11 @@ static void _acc_globals_update() {
  
 #endif /*BBCORE*/
  static double delta_t = 0.01;
+#pragma acc declare copyin(delta_t)
  static double h0 = 0;
+#pragma acc declare copyin(h0)
  static double m0 = 0;
+#pragma acc declare copyin(m0)
  /* connect global user variables to hoc */
  static DoubScal hoc_scdoub[] = {
  0,0
@@ -480,16 +486,7 @@ _thread = _ml->_thread;
     }
     #endif
   }
-
-#if defined(PG_ACC_BUGS)
-#if defined(celsius)
-#undef celsius;
-_celsius_ = celsius;
-#pragma acc update device (_celsius_) if(_nt->compute_gpu)
-#define celsius _celsius_
-#endif
-#endif
-_ACC_GLOBALS_UPDATE_
+_acc_globals_update();
 double * _nt_data = _nt->_data;
 double * _vec_v = _nt->_actual_v;
 int stream_id = _nt->stream_id;

--- a/test/validation/mod2c_core/cpp/NapIn.cpp
+++ b/test/validation/mod2c_core/cpp/NapIn.cpp
@@ -86,6 +86,10 @@
 #endif
  static int hoc_nrnpointerindex =  -1;
  /* external NEURON variables */
+ extern double celsius;
+ #define _celsius_ _celsius__napIn
+double _celsius_;
+#pragma acc declare copyin(_celsius_)
  
 #if 0 /*BBCORE*/
  /* declaration of user functions */
@@ -122,7 +126,11 @@ static void _acc_globals_update() {
  #pragma acc update device (hinf) if(nrn_threads->compute_gpu)
  #pragma acc update device (mtau) if(nrn_threads->compute_gpu)
  #pragma acc update device (minf) if(nrn_threads->compute_gpu)
+ _celsius_ = celsius;
+ #pragma acc update device(_celsius_)
  }
+
+ #define celsius _celsius_
  
 #if 0 /*BBCORE*/
  /* some parameters have upper and lower limits */
@@ -140,9 +148,13 @@ static void _acc_globals_update() {
  
 #endif /*BBCORE*/
  static double delta_t = 0.01;
+#pragma acc declare copyin(delta_t)
  static double h0 = 0;
+#pragma acc declare copyin(h0)
  static double m0 = 0;
+#pragma acc declare copyin(m0)
  static double v = 0;
+#pragma acc declare copyin(v)
  /* connect global user variables to hoc */
  static DoubScal hoc_scdoub[] = {
  "eNa_napIn", &eNa_napIn,

--- a/test/validation/mod2c_core/cpp/Nap_E.cpp
+++ b/test/validation/mod2c_core/cpp/Nap_E.cpp
@@ -40,14 +40,12 @@
 #define _PRAGMA_FOR_CUR_ACC_LOOP_ _Pragma("acc parallel loop present(_ni[0:_cntml_actual], _nt_data[0:_nt->_ndata], _p[0:_cntml_padded*_psize], _ppvar[0:_cntml_padded*_ppsize], _vec_v[0:_nt->end], _vec_d[0:_nt->end], _vec_rhs[0:_nt->end], _nt[0:1] _thread_present_) if(_nt->compute_gpu) async(stream_id)")
 #define _PRAGMA_FOR_CUR_SYN_ACC_LOOP_ _Pragma("acc parallel loop present(_ni[0:_cntml_actual], _nt_data[0:_nt->_ndata], _p[0:_cntml_padded*_psize], _ppvar[0:_cntml_padded*_ppsize], _vec_v[0:_nt->end], _vec_shadow_rhs[0:_nt->shadow_rhs_cnt], _vec_shadow_d[0:_nt->shadow_rhs_cnt], _vec_d[0:_nt->end], _vec_rhs[0:_nt->end], _nt[0:1]) if(_nt->compute_gpu) async(stream_id)")
 #define _PRAGMA_FOR_NETRECV_ACC_LOOP_ _Pragma("acc parallel loop present(_pnt[0:_pnt_length], _nrb[0:1], _nt[0:1], nrn_threads[0:nrn_nthread]) if(_nt->compute_gpu) async(stream_id)")
-#define _ACC_GLOBALS_UPDATE_ if (_nt->compute_gpu) {_acc_globals_update();}
 #else
 #define _PRAGMA_FOR_INIT_ACC_LOOP_ _Pragma("")
 #define _PRAGMA_FOR_STATE_ACC_LOOP_ _Pragma("")
 #define _PRAGMA_FOR_CUR_ACC_LOOP_ _Pragma("")
 #define _PRAGMA_FOR_CUR_SYN_ACC_LOOP_ _Pragma("")
 #define _PRAGMA_FOR_NETRECV_ACC_LOOP_ _Pragma("")
-#define _ACC_GLOBALS_UPDATE_ ;
 #endif
  
 #if defined(__clang__)
@@ -175,6 +173,7 @@
  
 static void _acc_globals_update() {
  }
+
  
 #if 0 /*BBCORE*/
  /* some parameters have upper and lower limits */
@@ -190,8 +189,11 @@ static void _acc_globals_update() {
  
 #endif /*BBCORE*/
  static double delta_t = 0.01;
+#pragma acc declare copyin(delta_t)
  static double h0 = 0;
+#pragma acc declare copyin(h0)
  static double m0 = 0;
+#pragma acc declare copyin(m0)
  /* connect global user variables to hoc */
  static DoubScal hoc_scdoub[] = {
  0,0
@@ -398,16 +400,7 @@ double _v, v; int* _ni; int _iml, _cntml_padded, _cntml_actual;
 _cntml_actual = _ml->_nodecount;
 _cntml_padded = _ml->_nodecount_padded;
 _thread = _ml->_thread;
-
-#if defined(PG_ACC_BUGS)
-#if defined(celsius)
-#undef celsius;
-_celsius_ = celsius;
-#pragma acc update device (_celsius_) if(_nt->compute_gpu)
-#define celsius _celsius_
-#endif
-#endif
-_ACC_GLOBALS_UPDATE_
+_acc_globals_update();
 double * _nt_data = _nt->_data;
 double * _vec_v = _nt->_actual_v;
 int stream_id = _nt->stream_id;

--- a/test/validation/mod2c_core/cpp/Nap_No.cpp
+++ b/test/validation/mod2c_core/cpp/Nap_No.cpp
@@ -40,14 +40,12 @@
 #define _PRAGMA_FOR_CUR_ACC_LOOP_ _Pragma("acc parallel loop present(_ni[0:_cntml_actual], _nt_data[0:_nt->_ndata], _p[0:_cntml_padded*_psize], _ppvar[0:_cntml_padded*_ppsize], _vec_v[0:_nt->end], _vec_d[0:_nt->end], _vec_rhs[0:_nt->end], _nt[0:1] _thread_present_) if(_nt->compute_gpu) async(stream_id)")
 #define _PRAGMA_FOR_CUR_SYN_ACC_LOOP_ _Pragma("acc parallel loop present(_ni[0:_cntml_actual], _nt_data[0:_nt->_ndata], _p[0:_cntml_padded*_psize], _ppvar[0:_cntml_padded*_ppsize], _vec_v[0:_nt->end], _vec_shadow_rhs[0:_nt->shadow_rhs_cnt], _vec_shadow_d[0:_nt->shadow_rhs_cnt], _vec_d[0:_nt->end], _vec_rhs[0:_nt->end], _nt[0:1]) if(_nt->compute_gpu) async(stream_id)")
 #define _PRAGMA_FOR_NETRECV_ACC_LOOP_ _Pragma("acc parallel loop present(_pnt[0:_pnt_length], _nrb[0:1], _nt[0:1], nrn_threads[0:nrn_nthread]) if(_nt->compute_gpu) async(stream_id)")
-#define _ACC_GLOBALS_UPDATE_ if (_nt->compute_gpu) {_acc_globals_update();}
 #else
 #define _PRAGMA_FOR_INIT_ACC_LOOP_ _Pragma("")
 #define _PRAGMA_FOR_STATE_ACC_LOOP_ _Pragma("")
 #define _PRAGMA_FOR_CUR_ACC_LOOP_ _Pragma("")
 #define _PRAGMA_FOR_CUR_SYN_ACC_LOOP_ _Pragma("")
 #define _PRAGMA_FOR_NETRECV_ACC_LOOP_ _Pragma("")
-#define _ACC_GLOBALS_UPDATE_ ;
 #endif
  
 #if defined(__clang__)
@@ -162,11 +160,13 @@
  
 #endif /*BBCORE*/
 #define vtrap vtrap_Nap_No
+ #pragma acc routine seq
  inline double vtrap( _threadargsprotocomma_ double , double );
  /* declare global and static user variables */
  
 static void _acc_globals_update() {
  }
+
  
 #if 0 /*BBCORE*/
  /* some parameters have upper and lower limits */
@@ -183,7 +183,9 @@ static void _acc_globals_update() {
  
 #endif /*BBCORE*/
  static double delta_t = 0.01;
+#pragma acc declare copyin(delta_t)
  static double p0 = 0;
+#pragma acc declare copyin(p0)
  /* connect global user variables to hoc */
  static DoubScal hoc_scdoub[] = {
  0,0
@@ -359,16 +361,7 @@ double _v, v; int* _ni; int _iml, _cntml_padded, _cntml_actual;
 _cntml_actual = _ml->_nodecount;
 _cntml_padded = _ml->_nodecount_padded;
 _thread = _ml->_thread;
-
-#if defined(PG_ACC_BUGS)
-#if defined(celsius)
-#undef celsius;
-_celsius_ = celsius;
-#pragma acc update device (_celsius_) if(_nt->compute_gpu)
-#define celsius _celsius_
-#endif
-#endif
-_ACC_GLOBALS_UPDATE_
+_acc_globals_update();
 double * _nt_data = _nt->_data;
 double * _vec_v = _nt->_actual_v;
 int stream_id = _nt->stream_id;

--- a/test/validation/mod2c_core/cpp/SynNMDA10_1.cpp
+++ b/test/validation/mod2c_core/cpp/SynNMDA10_1.cpp
@@ -300,6 +300,7 @@ static void _acc_globals_update() {
  #pragma acc update device (rmd1b) if(nrn_threads->compute_gpu)
  #pragma acc update device (valence) if(nrn_threads->compute_gpu)
  }
+
  
 #if 0 /*BBCORE*/
  /* some parameters have upper and lower limits */
@@ -360,17 +361,29 @@ static void _acc_globals_update() {
  
 #endif /*BBCORE*/
  static double ClMg0 = 0;
+#pragma acc declare copyin(ClMg0)
  static double Cl0 = 0;
+#pragma acc declare copyin(Cl0)
  static double D2Mg0 = 0;
+#pragma acc declare copyin(D2Mg0)
  static double D1Mg0 = 0;
+#pragma acc declare copyin(D1Mg0)
  static double D20 = 0;
+#pragma acc declare copyin(D20)
  static double D10 = 0;
+#pragma acc declare copyin(D10)
  static double OMg0 = 0;
+#pragma acc declare copyin(OMg0)
  static double O0 = 0;
+#pragma acc declare copyin(O0)
  static double UMg0 = 0;
+#pragma acc declare copyin(UMg0)
  static double U0 = 0;
+#pragma acc declare copyin(U0)
  static double delta_t = 1;
+#pragma acc declare copyin(delta_t)
  static double v = 0;
+#pragma acc declare copyin(v)
  /* connect global user variables to hoc */
  static DoubScal hoc_scdoub[] = {
  "mg_NMDA10_1", &mg_NMDA10_1,

--- a/test/validation/mod2c_core/cpp/SynNMDA10_2.cpp
+++ b/test/validation/mod2c_core/cpp/SynNMDA10_2.cpp
@@ -195,6 +195,7 @@ static void _acc_globals_update() {
  #pragma acc update device (Rb) if(nrn_threads->compute_gpu)
  #pragma acc update device (mg) if(nrn_threads->compute_gpu)
  }
+
  
 #if 0 /*BBCORE*/
  /* some parameters have upper and lower limits */
@@ -227,17 +228,29 @@ static void _acc_globals_update() {
  
 #endif /*BBCORE*/
  static double CB20 = 0;
+#pragma acc declare copyin(CB20)
  static double CB10 = 0;
+#pragma acc declare copyin(CB10)
  static double CB00 = 0;
+#pragma acc declare copyin(CB00)
  static double C20 = 0;
+#pragma acc declare copyin(C20)
  static double C10 = 0;
+#pragma acc declare copyin(C10)
  static double C00 = 0;
+#pragma acc declare copyin(C00)
  static double DB0 = 0;
+#pragma acc declare copyin(DB0)
  static double D0 = 0;
+#pragma acc declare copyin(D0)
  static double OB0 = 0;
+#pragma acc declare copyin(OB0)
  static double O0 = 0;
+#pragma acc declare copyin(O0)
  static double delta_t = 1;
+#pragma acc declare copyin(delta_t)
  static double v = 0;
+#pragma acc declare copyin(v)
  /* connect global user variables to hoc */
  static DoubScal hoc_scdoub[] = {
  "mg_NMDA10_2", &mg_NMDA10_2,

--- a/test/validation/mod2c_core/cpp/SynNMDA10_2_2.cpp
+++ b/test/validation/mod2c_core/cpp/SynNMDA10_2_2.cpp
@@ -40,14 +40,12 @@
 #define _PRAGMA_FOR_CUR_ACC_LOOP_ _Pragma("acc parallel loop present(_ni[0:_cntml_actual], _nt_data[0:_nt->_ndata], _p[0:_cntml_padded*_psize], _ppvar[0:_cntml_padded*_ppsize], _vec_v[0:_nt->end], _vec_d[0:_nt->end], _vec_rhs[0:_nt->end], _nt[0:1] _thread_present_) if(_nt->compute_gpu) async(stream_id)")
 #define _PRAGMA_FOR_CUR_SYN_ACC_LOOP_ _Pragma("acc parallel loop present(_ni[0:_cntml_actual], _nt_data[0:_nt->_ndata], _p[0:_cntml_padded*_psize], _ppvar[0:_cntml_padded*_ppsize], _vec_v[0:_nt->end], _vec_shadow_rhs[0:_nt->shadow_rhs_cnt], _vec_shadow_d[0:_nt->shadow_rhs_cnt], _vec_d[0:_nt->end], _vec_rhs[0:_nt->end], _nt[0:1]) if(_nt->compute_gpu) async(stream_id)")
 #define _PRAGMA_FOR_NETRECV_ACC_LOOP_ _Pragma("acc parallel loop present(_pnt[0:_pnt_length], _nrb[0:1], _nt[0:1], nrn_threads[0:nrn_nthread]) if(_nt->compute_gpu) async(stream_id)")
-#define _ACC_GLOBALS_UPDATE_ if (_nt->compute_gpu) {_acc_globals_update();}
 #else
 #define _PRAGMA_FOR_INIT_ACC_LOOP_ _Pragma("")
 #define _PRAGMA_FOR_STATE_ACC_LOOP_ _Pragma("")
 #define _PRAGMA_FOR_CUR_ACC_LOOP_ _Pragma("")
 #define _PRAGMA_FOR_CUR_SYN_ACC_LOOP_ _Pragma("")
 #define _PRAGMA_FOR_NETRECV_ACC_LOOP_ _Pragma("")
-#define _ACC_GLOBALS_UPDATE_ ;
 #endif
  
 #if defined(__clang__)
@@ -236,6 +234,7 @@ int _mechtype;
 static void _acc_globals_update() {
  #pragma acc update device (mg) if(nrn_threads->compute_gpu)
  }
+
  
 #if 0 /*BBCORE*/
  /* some parameters have upper and lower limits */
@@ -267,16 +266,27 @@ static void _acc_globals_update() {
  
 #endif /*BBCORE*/
  static double CB20 = 0;
+#pragma acc declare copyin(CB20)
  static double CB10 = 0;
+#pragma acc declare copyin(CB10)
  static double CB00 = 0;
+#pragma acc declare copyin(CB00)
  static double C20 = 0;
+#pragma acc declare copyin(C20)
  static double C10 = 0;
+#pragma acc declare copyin(C10)
  static double C00 = 0;
+#pragma acc declare copyin(C00)
  static double DB0 = 0;
+#pragma acc declare copyin(DB0)
  static double D0 = 0;
+#pragma acc declare copyin(D0)
  static double OB0 = 0;
+#pragma acc declare copyin(OB0)
  static double O0 = 0;
+#pragma acc declare copyin(O0)
  static double delta_t = 1;
+#pragma acc declare copyin(delta_t)
  /* connect global user variables to hoc */
  static DoubScal hoc_scdoub[] = {
  "mg_NMDA10_2_2", &mg_NMDA10_2_2,
@@ -994,16 +1004,7 @@ _thread = _ml->_thread;
     }
     #endif
   }
-
-#if defined(PG_ACC_BUGS)
-#if defined(celsius)
-#undef celsius;
-_celsius_ = celsius;
-#pragma acc update device (_celsius_) if(_nt->compute_gpu)
-#define celsius _celsius_
-#endif
-#endif
-_ACC_GLOBALS_UPDATE_
+_acc_globals_update();
 double * _nt_data = _nt->_data;
 double * _vec_v = _nt->_actual_v;
 int stream_id = _nt->stream_id;

--- a/test/validation/mod2c_core/cpp/SynNMDA16.cpp
+++ b/test/validation/mod2c_core/cpp/SynNMDA16.cpp
@@ -40,14 +40,12 @@
 #define _PRAGMA_FOR_CUR_ACC_LOOP_ _Pragma("acc parallel loop present(_ni[0:_cntml_actual], _nt_data[0:_nt->_ndata], _p[0:_cntml_padded*_psize], _ppvar[0:_cntml_padded*_ppsize], _vec_v[0:_nt->end], _vec_d[0:_nt->end], _vec_rhs[0:_nt->end], _nt[0:1] _thread_present_) if(_nt->compute_gpu) async(stream_id)")
 #define _PRAGMA_FOR_CUR_SYN_ACC_LOOP_ _Pragma("acc parallel loop present(_ni[0:_cntml_actual], _nt_data[0:_nt->_ndata], _p[0:_cntml_padded*_psize], _ppvar[0:_cntml_padded*_ppsize], _vec_v[0:_nt->end], _vec_shadow_rhs[0:_nt->shadow_rhs_cnt], _vec_shadow_d[0:_nt->shadow_rhs_cnt], _vec_d[0:_nt->end], _vec_rhs[0:_nt->end], _nt[0:1]) if(_nt->compute_gpu) async(stream_id)")
 #define _PRAGMA_FOR_NETRECV_ACC_LOOP_ _Pragma("acc parallel loop present(_pnt[0:_pnt_length], _nrb[0:1], _nt[0:1], nrn_threads[0:nrn_nthread]) if(_nt->compute_gpu) async(stream_id)")
-#define _ACC_GLOBALS_UPDATE_ if (_nt->compute_gpu) {_acc_globals_update();}
 #else
 #define _PRAGMA_FOR_INIT_ACC_LOOP_ _Pragma("")
 #define _PRAGMA_FOR_STATE_ACC_LOOP_ _Pragma("")
 #define _PRAGMA_FOR_CUR_ACC_LOOP_ _Pragma("")
 #define _PRAGMA_FOR_CUR_SYN_ACC_LOOP_ _Pragma("")
 #define _PRAGMA_FOR_NETRECV_ACC_LOOP_ _Pragma("")
-#define _ACC_GLOBALS_UPDATE_ ;
 #endif
  
 #if defined(__clang__)
@@ -334,6 +332,7 @@ static void _acc_globals_update() {
  #pragma acc update device (koff) if(nrn_threads->compute_gpu)
  #pragma acc update device (kon) if(nrn_threads->compute_gpu)
  }
+
  
 #if 0 /*BBCORE*/
  /* some parameters have upper and lower limits */
@@ -388,22 +387,39 @@ static void _acc_globals_update() {
  
 #endif /*BBCORE*/
  static double OMg0 = 0;
+#pragma acc declare copyin(OMg0)
  static double O0 = 0;
+#pragma acc declare copyin(O0)
  static double RA2sMg0 = 0;
+#pragma acc declare copyin(RA2sMg0)
  static double RA2fMg0 = 0;
+#pragma acc declare copyin(RA2fMg0)
  static double RA2d2Mg0 = 0;
+#pragma acc declare copyin(RA2d2Mg0)
  static double RA2d1Mg0 = 0;
+#pragma acc declare copyin(RA2d1Mg0)
  static double RA2Mg0 = 0;
+#pragma acc declare copyin(RA2Mg0)
  static double RAMg0 = 0;
+#pragma acc declare copyin(RAMg0)
  static double RMg0 = 0;
+#pragma acc declare copyin(RMg0)
  static double RA2s0 = 0;
+#pragma acc declare copyin(RA2s0)
  static double RA2f0 = 0;
+#pragma acc declare copyin(RA2f0)
  static double RA2d20 = 0;
+#pragma acc declare copyin(RA2d20)
  static double RA2d10 = 0;
+#pragma acc declare copyin(RA2d10)
  static double RA20 = 0;
+#pragma acc declare copyin(RA20)
  static double RA0 = 0;
+#pragma acc declare copyin(RA0)
  static double R0 = 0;
+#pragma acc declare copyin(R0)
  static double delta_t = 1;
+#pragma acc declare copyin(delta_t)
  /* connect global user variables to hoc */
  static DoubScal hoc_scdoub[] = {
  "gmax_NMDA16", &gmax_NMDA16,
@@ -1318,16 +1334,7 @@ _thread = _ml->_thread;
     }
     #endif
   }
-
-#if defined(PG_ACC_BUGS)
-#if defined(celsius)
-#undef celsius;
-_celsius_ = celsius;
-#pragma acc update device (_celsius_) if(_nt->compute_gpu)
-#define celsius _celsius_
-#endif
-#endif
-_ACC_GLOBALS_UPDATE_
+_acc_globals_update();
 double * _nt_data = _nt->_data;
 double * _vec_v = _nt->_actual_v;
 int stream_id = _nt->stream_id;

--- a/test/validation/mod2c_core/cpp/SynNMDA16_2.cpp
+++ b/test/validation/mod2c_core/cpp/SynNMDA16_2.cpp
@@ -40,14 +40,12 @@
 #define _PRAGMA_FOR_CUR_ACC_LOOP_ _Pragma("acc parallel loop present(_ni[0:_cntml_actual], _nt_data[0:_nt->_ndata], _p[0:_cntml_padded*_psize], _ppvar[0:_cntml_padded*_ppsize], _vec_v[0:_nt->end], _vec_d[0:_nt->end], _vec_rhs[0:_nt->end], _nt[0:1] _thread_present_) if(_nt->compute_gpu) async(stream_id)")
 #define _PRAGMA_FOR_CUR_SYN_ACC_LOOP_ _Pragma("acc parallel loop present(_ni[0:_cntml_actual], _nt_data[0:_nt->_ndata], _p[0:_cntml_padded*_psize], _ppvar[0:_cntml_padded*_ppsize], _vec_v[0:_nt->end], _vec_shadow_rhs[0:_nt->shadow_rhs_cnt], _vec_shadow_d[0:_nt->shadow_rhs_cnt], _vec_d[0:_nt->end], _vec_rhs[0:_nt->end], _nt[0:1]) if(_nt->compute_gpu) async(stream_id)")
 #define _PRAGMA_FOR_NETRECV_ACC_LOOP_ _Pragma("acc parallel loop present(_pnt[0:_pnt_length], _nrb[0:1], _nt[0:1], nrn_threads[0:nrn_nthread]) if(_nt->compute_gpu) async(stream_id)")
-#define _ACC_GLOBALS_UPDATE_ if (_nt->compute_gpu) {_acc_globals_update();}
 #else
 #define _PRAGMA_FOR_INIT_ACC_LOOP_ _Pragma("")
 #define _PRAGMA_FOR_STATE_ACC_LOOP_ _Pragma("")
 #define _PRAGMA_FOR_CUR_ACC_LOOP_ _Pragma("")
 #define _PRAGMA_FOR_CUR_SYN_ACC_LOOP_ _Pragma("")
 #define _PRAGMA_FOR_NETRECV_ACC_LOOP_ _Pragma("")
-#define _ACC_GLOBALS_UPDATE_ ;
 #endif
  
 #if defined(__clang__)
@@ -345,6 +343,7 @@ static void _acc_globals_update() {
  #pragma acc update device (kNo) if(nrn_threads->compute_gpu)
  #pragma acc update device (kP) if(nrn_threads->compute_gpu)
  }
+
  
 #if 0 /*BBCORE*/
  /* some parameters have upper and lower limits */
@@ -399,22 +398,39 @@ static void _acc_globals_update() {
  
 #endif /*BBCORE*/
  static double OMg0 = 0;
+#pragma acc declare copyin(OMg0)
  static double O0 = 0;
+#pragma acc declare copyin(O0)
  static double RA2sMg0 = 0;
+#pragma acc declare copyin(RA2sMg0)
  static double RA2fMg0 = 0;
+#pragma acc declare copyin(RA2fMg0)
  static double RA2d2Mg0 = 0;
+#pragma acc declare copyin(RA2d2Mg0)
  static double RA2d1Mg0 = 0;
+#pragma acc declare copyin(RA2d1Mg0)
  static double RA2Mg0 = 0;
+#pragma acc declare copyin(RA2Mg0)
  static double RAMg0 = 0;
+#pragma acc declare copyin(RAMg0)
  static double RMg0 = 0;
+#pragma acc declare copyin(RMg0)
  static double RA2s0 = 0;
+#pragma acc declare copyin(RA2s0)
  static double RA2f0 = 0;
+#pragma acc declare copyin(RA2f0)
  static double RA2d20 = 0;
+#pragma acc declare copyin(RA2d20)
  static double RA2d10 = 0;
+#pragma acc declare copyin(RA2d10)
  static double RA20 = 0;
+#pragma acc declare copyin(RA20)
  static double RA0 = 0;
+#pragma acc declare copyin(RA0)
  static double R0 = 0;
+#pragma acc declare copyin(R0)
  static double delta_t = 1;
+#pragma acc declare copyin(delta_t)
  /* connect global user variables to hoc */
  static DoubScal hoc_scdoub[] = {
  "gmax_NMDA16_2", &gmax_NMDA16_2,
@@ -1402,16 +1418,7 @@ _thread = _ml->_thread;
     }
     #endif
   }
-
-#if defined(PG_ACC_BUGS)
-#if defined(celsius)
-#undef celsius;
-_celsius_ = celsius;
-#pragma acc update device (_celsius_) if(_nt->compute_gpu)
-#define celsius _celsius_
-#endif
-#endif
-_ACC_GLOBALS_UPDATE_
+_acc_globals_update();
 double * _nt_data = _nt->_data;
 double * _vec_v = _nt->_actual_v;
 int stream_id = _nt->stream_id;

--- a/test/validation/mod2c_core/cpp/is.cpp
+++ b/test/validation/mod2c_core/cpp/is.cpp
@@ -40,14 +40,12 @@
 #define _PRAGMA_FOR_CUR_ACC_LOOP_ _Pragma("acc parallel loop present(_ni[0:_cntml_actual], _nt_data[0:_nt->_ndata], _p[0:_cntml_padded*_psize], _ppvar[0:_cntml_padded*_ppsize], _vec_v[0:_nt->end], _vec_d[0:_nt->end], _vec_rhs[0:_nt->end], _nt[0:1] _thread_present_) if(_nt->compute_gpu) async(stream_id)")
 #define _PRAGMA_FOR_CUR_SYN_ACC_LOOP_ _Pragma("acc parallel loop present(_ni[0:_cntml_actual], _nt_data[0:_nt->_ndata], _p[0:_cntml_padded*_psize], _ppvar[0:_cntml_padded*_ppsize], _vec_v[0:_nt->end], _vec_shadow_rhs[0:_nt->shadow_rhs_cnt], _vec_shadow_d[0:_nt->shadow_rhs_cnt], _vec_d[0:_nt->end], _vec_rhs[0:_nt->end], _nt[0:1]) if(_nt->compute_gpu) async(stream_id)")
 #define _PRAGMA_FOR_NETRECV_ACC_LOOP_ _Pragma("acc parallel loop present(_pnt[0:_pnt_length], _nrb[0:1], _nt[0:1], nrn_threads[0:nrn_nthread]) if(_nt->compute_gpu) async(stream_id)")
-#define _ACC_GLOBALS_UPDATE_ if (_nt->compute_gpu) {_acc_globals_update();}
 #else
 #define _PRAGMA_FOR_INIT_ACC_LOOP_ _Pragma("")
 #define _PRAGMA_FOR_STATE_ACC_LOOP_ _Pragma("")
 #define _PRAGMA_FOR_CUR_ACC_LOOP_ _Pragma("")
 #define _PRAGMA_FOR_CUR_SYN_ACC_LOOP_ _Pragma("")
 #define _PRAGMA_FOR_NETRECV_ACC_LOOP_ _Pragma("")
-#define _ACC_GLOBALS_UPDATE_ ;
 #endif
  
 #if defined(__clang__)
@@ -148,6 +146,10 @@
  static int hoc_nrnpointerindex =  -1;
  static ThreadDatum* _extcall_thread;
  /* external NEURON variables */
+ extern double celsius;
+ #define _celsius_ _celsius__Is
+double _celsius_;
+#pragma acc declare copyin(_celsius_)
  
 #if 0 /*BBCORE*/
  /* declaration of user functions */
@@ -171,7 +173,9 @@
 #endif /*BBCORE*/
 #define alp alp_Is
 #define bet bet_Is
+ #pragma acc routine seq
  inline double alp( _threadargsprotocomma_ double , double );
+ #pragma acc routine seq
  inline double bet( _threadargsprotocomma_ double , double );
  /* declare global and static user variables */
  static int _thread1data_inuse = 0;
@@ -187,7 +191,11 @@ static double _thread1data[4];
 #define ninf _thread[_gth]._pval[3]
  
 static void _acc_globals_update() {
+ _celsius_ = celsius;
+ #pragma acc update device(_celsius_)
  }
+
+ #define celsius _celsius_
  
 #if 0 /*BBCORE*/
  /* some parameters have upper and lower limits */
@@ -206,8 +214,11 @@ static void _acc_globals_update() {
  
 #endif /*BBCORE*/
  static double delta_t = 0.01;
+#pragma acc declare copyin(delta_t)
  static double m0 = 0;
+#pragma acc declare copyin(m0)
  static double n0 = 0;
+#pragma acc declare copyin(n0)
  /* connect global user variables to hoc */
  static DoubScal hoc_scdoub[] = {
  "minf_Is", &minf_Is,
@@ -513,16 +524,7 @@ _thread = _ml->_thread;
     }
     #endif
   }
-
-#if defined(PG_ACC_BUGS)
-#if defined(celsius)
-#undef celsius;
-_celsius_ = celsius;
-#pragma acc update device (_celsius_) if(_nt->compute_gpu)
-#define celsius _celsius_
-#endif
-#endif
-_ACC_GLOBALS_UPDATE_
+_acc_globals_update();
 double * _nt_data = _nt->_data;
 double * _vec_v = _nt->_actual_v;
 int stream_id = _nt->stream_id;

--- a/test/validation/mod2c_core/cpp/zoidsyn.cpp
+++ b/test/validation/mod2c_core/cpp/zoidsyn.cpp
@@ -40,14 +40,12 @@
 #define _PRAGMA_FOR_CUR_ACC_LOOP_ _Pragma("acc parallel loop present(_ni[0:_cntml_actual], _nt_data[0:_nt->_ndata], _p[0:_cntml_padded*_psize], _ppvar[0:_cntml_padded*_ppsize], _vec_v[0:_nt->end], _vec_d[0:_nt->end], _vec_rhs[0:_nt->end], _nt[0:1] _thread_present_) if(_nt->compute_gpu) async(stream_id)")
 #define _PRAGMA_FOR_CUR_SYN_ACC_LOOP_ _Pragma("acc parallel loop present(_ni[0:_cntml_actual], _nt_data[0:_nt->_ndata], _p[0:_cntml_padded*_psize], _ppvar[0:_cntml_padded*_ppsize], _vec_v[0:_nt->end], _vec_shadow_rhs[0:_nt->shadow_rhs_cnt], _vec_shadow_d[0:_nt->shadow_rhs_cnt], _vec_d[0:_nt->end], _vec_rhs[0:_nt->end], _nt[0:1]) if(_nt->compute_gpu) async(stream_id)")
 #define _PRAGMA_FOR_NETRECV_ACC_LOOP_ _Pragma("acc parallel loop present(_pnt[0:_pnt_length], _nrb[0:1], _nt[0:1], nrn_threads[0:nrn_nthread]) if(_nt->compute_gpu) async(stream_id)")
-#define _ACC_GLOBALS_UPDATE_ if (_nt->compute_gpu) {_acc_globals_update();}
 #else
 #define _PRAGMA_FOR_INIT_ACC_LOOP_ _Pragma("")
 #define _PRAGMA_FOR_STATE_ACC_LOOP_ _Pragma("")
 #define _PRAGMA_FOR_CUR_ACC_LOOP_ _Pragma("")
 #define _PRAGMA_FOR_CUR_SYN_ACC_LOOP_ _Pragma("")
 #define _PRAGMA_FOR_NETRECV_ACC_LOOP_ _Pragma("")
-#define _ACC_GLOBALS_UPDATE_ ;
 #endif
  
 #if defined(__clang__)
@@ -201,6 +199,7 @@ int _mechtype;
  
 static void _acc_globals_update() {
  }
+
  
 #if 0 /*BBCORE*/
  /* some parameters have upper and lower limits */
@@ -550,16 +549,7 @@ _cntml_actual = _ml->_nodecount;
 _cntml_padded = _ml->_nodecount_padded;
 _thread = _ml->_thread;
   #pragma acc update device (_mechtype) if(_nt->compute_gpu)
-
-#if defined(PG_ACC_BUGS)
-#if defined(celsius)
-#undef celsius;
-_celsius_ = celsius;
-#pragma acc update device (_celsius_) if(_nt->compute_gpu)
-#define celsius _celsius_
-#endif
-#endif
-_ACC_GLOBALS_UPDATE_
+_acc_globals_update();
 double * _nt_data = _nt->_data;
 double * _vec_v = _nt->_actual_v;
 int stream_id = _nt->stream_id;


### PR DESCRIPTION
Hi Michael,

I spent some time digging into different PGI compiler versions and why C++ code from mod2c wasn't working for GPU. Here is summary : 

* When there are large functions, especially nested ones, nrn_state()->state()->rates()->trates().....and son : pgc++ doesn't inline all functions. Same call chain gets inlined if its .c file (i.e. pgcc). We have pragma annotation for `nrn_state` only. As inlining is failed, pgc++ gives error while generating gpu code. Solution for this is : 

```

#pragma acc routine seq
int state() {

}

#pragma routine seq
int rates() {

}

double nrn_state() {

      #pragma acc parallel for
      for () {
             .........
      }
}

```

With this, when inlining is failed, device kernel is generated for `state` and other functions. This way, gpu code can work fine. So, now all functions/procedures are marked with `acc routine seq`

* Another issue is with extern & static variables, for example celsius. We added workaround for `PGI v 16.3` when celsius was not working properly. Note that celsius is "external" variable. We have marked all functions with `acc routine seq` but there is additional restriction with this : such routines can't use any extern/static variables. This means, we have to have to replace `celsius` with `_celsius_` in every mod2c generated file.

So, `PG_ACC_BUGS` is now kind of requirement with C++ code generation. 


* All static variables in the file needs to be marked with `pragma acc declare copyin`

With this changeset and coreneuron master branch, I am able to build ring,traub,dentate models. 

> I have tested only ringtest model (with gap juctions, permute etc). Will test other models soon.

I will do `clang-format` for the mod2c code (mixed indention issue)

Note : once you approve, I will fix the tests and then we can merge.