### PR TITLE
Bug fix for intel ivdep pragma order

### DIFF
--- a/src/mod2c_core/nocpout.c
+++ b/src/mod2c_core/nocpout.c
@@ -392,9 +392,7 @@ fprintf(stderr, "Notice: ARTIFICIAL_CELL models that would require thread specif
 \n#define _PRAGMA_FOR_NETRECV_ACC_LOOP_ _Pragma(\"\")\
 \n#endif\
 \n \
-\n#if defined(__clang__)\
-\n#define _PRAGMA_FOR_VECTOR_LOOP_ _Pragma(\"clang loop vectorize(enable)\")\
-\n#elif defined(__ICC) || defined(__INTEL_COMPILER)\
+\n#if defined(__ICC) || defined(__INTEL_COMPILER)\
 \n#define _PRAGMA_FOR_VECTOR_LOOP_ _Pragma(\"ivdep\")\
 \n#elif defined(__IBMC__) || defined(__IBMCPP__)\
 \n#define _PRAGMA_FOR_VECTOR_LOOP_ _Pragma(\"ibm independent_loop\")\
@@ -402,6 +400,8 @@ fprintf(stderr, "Notice: ARTIFICIAL_CELL models that would require thread specif
 \n#define _PRAGMA_FOR_VECTOR_LOOP_ _Pragma(\"vector\")\
 \n#elif defined(_CRAYC)\
 \n#define _PRAGMA_FOR_VECTOR_LOOP_ _Pragma(\"_CRI ivdep\")\
+\n#elif defined(__clang__)\
+\n#define _PRAGMA_FOR_VECTOR_LOOP_ _Pragma(\"clang loop vectorize(enable)\")\
 \n#elif defined(__GNUC__) || defined(__GNUG__)\
 \n#define _PRAGMA_FOR_VECTOR_LOOP_ _Pragma(\"GCC ivdep\")\
 \n#else\

--- a/test/validation/mod2c_core/cpp/NaSm.cpp
+++ b/test/validation/mod2c_core/cpp/NaSm.cpp
@@ -31,6 +31,9 @@
  
 #if defined(_OPENACC) && !defined(DISABLE_OPENACC)
 #include <openacc.h>
+#if defined(__PGI)
+#include "accelmath.h"
+#endif
 #if defined(PG_ACC_BUGS)
 #define _PRAGMA_FOR_INIT_ACC_LOOP_ _Pragma("acc parallel loop present(_ni[0:_cntml_actual], _nt_data[0:_nt->_ndata], _p[0:_cntml_padded*_psize], _ppvar[0:_cntml_padded*_ppsize], _vec_v[0:_nt->end], nrn_ion_global_map[0:nrn_ion_global_map_size][0:3], _nt[0:1] _thread_present_) if(_nt->compute_gpu)")
 #else
@@ -48,9 +51,7 @@
 #define _PRAGMA_FOR_NETRECV_ACC_LOOP_ _Pragma("")
 #endif
  
-#if defined(__clang__)
-#define _PRAGMA_FOR_VECTOR_LOOP_ _Pragma("clang loop vectorize(enable)")
-#elif defined(__ICC) || defined(__INTEL_COMPILER)
+#if defined(__ICC) || defined(__INTEL_COMPILER)
 #define _PRAGMA_FOR_VECTOR_LOOP_ _Pragma("ivdep")
 #elif defined(__IBMC__) || defined(__IBMCPP__)
 #define _PRAGMA_FOR_VECTOR_LOOP_ _Pragma("ibm independent_loop")
@@ -58,6 +59,8 @@
 #define _PRAGMA_FOR_VECTOR_LOOP_ _Pragma("vector")
 #elif defined(_CRAYC)
 #define _PRAGMA_FOR_VECTOR_LOOP_ _Pragma("_CRI ivdep")
+#elif defined(__clang__)
+#define _PRAGMA_FOR_VECTOR_LOOP_ _Pragma("clang loop vectorize(enable)")
 #elif defined(__GNUC__) || defined(__GNUG__)
 #define _PRAGMA_FOR_VECTOR_LOOP_ _Pragma("GCC ivdep")
 #else

--- a/test/validation/mod2c_core/cpp/NapDA.cpp
+++ b/test/validation/mod2c_core/cpp/NapDA.cpp
@@ -31,6 +31,9 @@
  
 #if defined(_OPENACC) && !defined(DISABLE_OPENACC)
 #include <openacc.h>
+#if defined(__PGI)
+#include "accelmath.h"
+#endif
 #if defined(PG_ACC_BUGS)
 #define _PRAGMA_FOR_INIT_ACC_LOOP_ _Pragma("acc parallel loop present(_ni[0:_cntml_actual], _nt_data[0:_nt->_ndata], _p[0:_cntml_padded*_psize], _ppvar[0:_cntml_padded*_ppsize], _vec_v[0:_nt->end], nrn_ion_global_map[0:nrn_ion_global_map_size][0:3], _nt[0:1] _thread_present_) if(_nt->compute_gpu)")
 #else
@@ -48,9 +51,7 @@
 #define _PRAGMA_FOR_NETRECV_ACC_LOOP_ _Pragma("")
 #endif
  
-#if defined(__clang__)
-#define _PRAGMA_FOR_VECTOR_LOOP_ _Pragma("clang loop vectorize(enable)")
-#elif defined(__ICC) || defined(__INTEL_COMPILER)
+#if defined(__ICC) || defined(__INTEL_COMPILER)
 #define _PRAGMA_FOR_VECTOR_LOOP_ _Pragma("ivdep")
 #elif defined(__IBMC__) || defined(__IBMCPP__)
 #define _PRAGMA_FOR_VECTOR_LOOP_ _Pragma("ibm independent_loop")
@@ -58,6 +59,8 @@
 #define _PRAGMA_FOR_VECTOR_LOOP_ _Pragma("vector")
 #elif defined(_CRAYC)
 #define _PRAGMA_FOR_VECTOR_LOOP_ _Pragma("_CRI ivdep")
+#elif defined(__clang__)
+#define _PRAGMA_FOR_VECTOR_LOOP_ _Pragma("clang loop vectorize(enable)")
 #elif defined(__GNUC__) || defined(__GNUG__)
 #define _PRAGMA_FOR_VECTOR_LOOP_ _Pragma("GCC ivdep")
 #else

--- a/test/validation/mod2c_core/cpp/Nap_E.cpp
+++ b/test/validation/mod2c_core/cpp/Nap_E.cpp
@@ -31,6 +31,9 @@
  
 #if defined(_OPENACC) && !defined(DISABLE_OPENACC)
 #include <openacc.h>
+#if defined(__PGI)
+#include "accelmath.h"
+#endif
 #if defined(PG_ACC_BUGS)
 #define _PRAGMA_FOR_INIT_ACC_LOOP_ _Pragma("acc parallel loop present(_ni[0:_cntml_actual], _nt_data[0:_nt->_ndata], _p[0:_cntml_padded*_psize], _ppvar[0:_cntml_padded*_ppsize], _vec_v[0:_nt->end], nrn_ion_global_map[0:nrn_ion_global_map_size][0:3], _nt[0:1] _thread_present_) if(_nt->compute_gpu)")
 #else
@@ -48,9 +51,7 @@
 #define _PRAGMA_FOR_NETRECV_ACC_LOOP_ _Pragma("")
 #endif
  
-#if defined(__clang__)
-#define _PRAGMA_FOR_VECTOR_LOOP_ _Pragma("clang loop vectorize(enable)")
-#elif defined(__ICC) || defined(__INTEL_COMPILER)
+#if defined(__ICC) || defined(__INTEL_COMPILER)
 #define _PRAGMA_FOR_VECTOR_LOOP_ _Pragma("ivdep")
 #elif defined(__IBMC__) || defined(__IBMCPP__)
 #define _PRAGMA_FOR_VECTOR_LOOP_ _Pragma("ibm independent_loop")
@@ -58,6 +59,8 @@
 #define _PRAGMA_FOR_VECTOR_LOOP_ _Pragma("vector")
 #elif defined(_CRAYC)
 #define _PRAGMA_FOR_VECTOR_LOOP_ _Pragma("_CRI ivdep")
+#elif defined(__clang__)
+#define _PRAGMA_FOR_VECTOR_LOOP_ _Pragma("clang loop vectorize(enable)")
 #elif defined(__GNUC__) || defined(__GNUG__)
 #define _PRAGMA_FOR_VECTOR_LOOP_ _Pragma("GCC ivdep")
 #else

--- a/test/validation/mod2c_core/cpp/Nap_No.cpp
+++ b/test/validation/mod2c_core/cpp/Nap_No.cpp
@@ -31,6 +31,9 @@
  
 #if defined(_OPENACC) && !defined(DISABLE_OPENACC)
 #include <openacc.h>
+#if defined(__PGI)
+#include "accelmath.h"
+#endif
 #if defined(PG_ACC_BUGS)
 #define _PRAGMA_FOR_INIT_ACC_LOOP_ _Pragma("acc parallel loop present(_ni[0:_cntml_actual], _nt_data[0:_nt->_ndata], _p[0:_cntml_padded*_psize], _ppvar[0:_cntml_padded*_ppsize], _vec_v[0:_nt->end], nrn_ion_global_map[0:nrn_ion_global_map_size][0:3], _nt[0:1] _thread_present_) if(_nt->compute_gpu)")
 #else
@@ -48,9 +51,7 @@
 #define _PRAGMA_FOR_NETRECV_ACC_LOOP_ _Pragma("")
 #endif
  
-#if defined(__clang__)
-#define _PRAGMA_FOR_VECTOR_LOOP_ _Pragma("clang loop vectorize(enable)")
-#elif defined(__ICC) || defined(__INTEL_COMPILER)
+#if defined(__ICC) || defined(__INTEL_COMPILER)
 #define _PRAGMA_FOR_VECTOR_LOOP_ _Pragma("ivdep")
 #elif defined(__IBMC__) || defined(__IBMCPP__)
 #define _PRAGMA_FOR_VECTOR_LOOP_ _Pragma("ibm independent_loop")
@@ -58,6 +59,8 @@
 #define _PRAGMA_FOR_VECTOR_LOOP_ _Pragma("vector")
 #elif defined(_CRAYC)
 #define _PRAGMA_FOR_VECTOR_LOOP_ _Pragma("_CRI ivdep")
+#elif defined(__clang__)
+#define _PRAGMA_FOR_VECTOR_LOOP_ _Pragma("clang loop vectorize(enable)")
 #elif defined(__GNUC__) || defined(__GNUG__)
 #define _PRAGMA_FOR_VECTOR_LOOP_ _Pragma("GCC ivdep")
 #else

--- a/test/validation/mod2c_core/cpp/SynNMDA10_2_2.cpp
+++ b/test/validation/mod2c_core/cpp/SynNMDA10_2_2.cpp
@@ -31,6 +31,9 @@
  
 #if defined(_OPENACC) && !defined(DISABLE_OPENACC)
 #include <openacc.h>
+#if defined(__PGI)
+#include "accelmath.h"
+#endif
 #if defined(PG_ACC_BUGS)
 #define _PRAGMA_FOR_INIT_ACC_LOOP_ _Pragma("acc parallel loop present(_ni[0:_cntml_actual], _nt_data[0:_nt->_ndata], _p[0:_cntml_padded*_psize], _ppvar[0:_cntml_padded*_ppsize], _vec_v[0:_nt->end], nrn_ion_global_map[0:nrn_ion_global_map_size][0:3], _nt[0:1] _thread_present_) if(_nt->compute_gpu)")
 #else
@@ -48,9 +51,7 @@
 #define _PRAGMA_FOR_NETRECV_ACC_LOOP_ _Pragma("")
 #endif
  
-#if defined(__clang__)
-#define _PRAGMA_FOR_VECTOR_LOOP_ _Pragma("clang loop vectorize(enable)")
-#elif defined(__ICC) || defined(__INTEL_COMPILER)
+#if defined(__ICC) || defined(__INTEL_COMPILER)
 #define _PRAGMA_FOR_VECTOR_LOOP_ _Pragma("ivdep")
 #elif defined(__IBMC__) || defined(__IBMCPP__)
 #define _PRAGMA_FOR_VECTOR_LOOP_ _Pragma("ibm independent_loop")
@@ -58,6 +59,8 @@
 #define _PRAGMA_FOR_VECTOR_LOOP_ _Pragma("vector")
 #elif defined(_CRAYC)
 #define _PRAGMA_FOR_VECTOR_LOOP_ _Pragma("_CRI ivdep")
+#elif defined(__clang__)
+#define _PRAGMA_FOR_VECTOR_LOOP_ _Pragma("clang loop vectorize(enable)")
 #elif defined(__GNUC__) || defined(__GNUG__)
 #define _PRAGMA_FOR_VECTOR_LOOP_ _Pragma("GCC ivdep")
 #else

--- a/test/validation/mod2c_core/cpp/SynNMDA16.cpp
+++ b/test/validation/mod2c_core/cpp/SynNMDA16.cpp
@@ -31,6 +31,9 @@
  
 #if defined(_OPENACC) && !defined(DISABLE_OPENACC)
 #include <openacc.h>
+#if defined(__PGI)
+#include "accelmath.h"
+#endif
 #if defined(PG_ACC_BUGS)
 #define _PRAGMA_FOR_INIT_ACC_LOOP_ _Pragma("acc parallel loop present(_ni[0:_cntml_actual], _nt_data[0:_nt->_ndata], _p[0:_cntml_padded*_psize], _ppvar[0:_cntml_padded*_ppsize], _vec_v[0:_nt->end], nrn_ion_global_map[0:nrn_ion_global_map_size][0:3], _nt[0:1] _thread_present_) if(_nt->compute_gpu)")
 #else
@@ -48,9 +51,7 @@
 #define _PRAGMA_FOR_NETRECV_ACC_LOOP_ _Pragma("")
 #endif
  
-#if defined(__clang__)
-#define _PRAGMA_FOR_VECTOR_LOOP_ _Pragma("clang loop vectorize(enable)")
-#elif defined(__ICC) || defined(__INTEL_COMPILER)
+#if defined(__ICC) || defined(__INTEL_COMPILER)
 #define _PRAGMA_FOR_VECTOR_LOOP_ _Pragma("ivdep")
 #elif defined(__IBMC__) || defined(__IBMCPP__)
 #define _PRAGMA_FOR_VECTOR_LOOP_ _Pragma("ibm independent_loop")
@@ -58,6 +59,8 @@
 #define _PRAGMA_FOR_VECTOR_LOOP_ _Pragma("vector")
 #elif defined(_CRAYC)
 #define _PRAGMA_FOR_VECTOR_LOOP_ _Pragma("_CRI ivdep")
+#elif defined(__clang__)
+#define _PRAGMA_FOR_VECTOR_LOOP_ _Pragma("clang loop vectorize(enable)")
 #elif defined(__GNUC__) || defined(__GNUG__)
 #define _PRAGMA_FOR_VECTOR_LOOP_ _Pragma("GCC ivdep")
 #else

--- a/test/validation/mod2c_core/cpp/SynNMDA16_2.cpp
+++ b/test/validation/mod2c_core/cpp/SynNMDA16_2.cpp
@@ -31,6 +31,9 @@
  
 #if defined(_OPENACC) && !defined(DISABLE_OPENACC)
 #include <openacc.h>
+#if defined(__PGI)
+#include "accelmath.h"
+#endif
 #if defined(PG_ACC_BUGS)
 #define _PRAGMA_FOR_INIT_ACC_LOOP_ _Pragma("acc parallel loop present(_ni[0:_cntml_actual], _nt_data[0:_nt->_ndata], _p[0:_cntml_padded*_psize], _ppvar[0:_cntml_padded*_ppsize], _vec_v[0:_nt->end], nrn_ion_global_map[0:nrn_ion_global_map_size][0:3], _nt[0:1] _thread_present_) if(_nt->compute_gpu)")
 #else
@@ -48,9 +51,7 @@
 #define _PRAGMA_FOR_NETRECV_ACC_LOOP_ _Pragma("")
 #endif
  
-#if defined(__clang__)
-#define _PRAGMA_FOR_VECTOR_LOOP_ _Pragma("clang loop vectorize(enable)")
-#elif defined(__ICC) || defined(__INTEL_COMPILER)
+#if defined(__ICC) || defined(__INTEL_COMPILER)
 #define _PRAGMA_FOR_VECTOR_LOOP_ _Pragma("ivdep")
 #elif defined(__IBMC__) || defined(__IBMCPP__)
 #define _PRAGMA_FOR_VECTOR_LOOP_ _Pragma("ibm independent_loop")
@@ -58,6 +59,8 @@
 #define _PRAGMA_FOR_VECTOR_LOOP_ _Pragma("vector")
 #elif defined(_CRAYC)
 #define _PRAGMA_FOR_VECTOR_LOOP_ _Pragma("_CRI ivdep")
+#elif defined(__clang__)
+#define _PRAGMA_FOR_VECTOR_LOOP_ _Pragma("clang loop vectorize(enable)")
 #elif defined(__GNUC__) || defined(__GNUG__)
 #define _PRAGMA_FOR_VECTOR_LOOP_ _Pragma("GCC ivdep")
 #else

--- a/test/validation/mod2c_core/cpp/is.cpp
+++ b/test/validation/mod2c_core/cpp/is.cpp
@@ -31,6 +31,9 @@
  
 #if defined(_OPENACC) && !defined(DISABLE_OPENACC)
 #include <openacc.h>
+#if defined(__PGI)
+#include "accelmath.h"
+#endif
 #if defined(PG_ACC_BUGS)
 #define _PRAGMA_FOR_INIT_ACC_LOOP_ _Pragma("acc parallel loop present(_ni[0:_cntml_actual], _nt_data[0:_nt->_ndata], _p[0:_cntml_padded*_psize], _ppvar[0:_cntml_padded*_ppsize], _vec_v[0:_nt->end], nrn_ion_global_map[0:nrn_ion_global_map_size][0:3], _nt[0:1] _thread_present_) if(_nt->compute_gpu)")
 #else
@@ -48,9 +51,7 @@
 #define _PRAGMA_FOR_NETRECV_ACC_LOOP_ _Pragma("")
 #endif
  
-#if defined(__clang__)
-#define _PRAGMA_FOR_VECTOR_LOOP_ _Pragma("clang loop vectorize(enable)")
-#elif defined(__ICC) || defined(__INTEL_COMPILER)
+#if defined(__ICC) || defined(__INTEL_COMPILER)
 #define _PRAGMA_FOR_VECTOR_LOOP_ _Pragma("ivdep")
 #elif defined(__IBMC__) || defined(__IBMCPP__)
 #define _PRAGMA_FOR_VECTOR_LOOP_ _Pragma("ibm independent_loop")
@@ -58,6 +59,8 @@
 #define _PRAGMA_FOR_VECTOR_LOOP_ _Pragma("vector")
 #elif defined(_CRAYC)
 #define _PRAGMA_FOR_VECTOR_LOOP_ _Pragma("_CRI ivdep")
+#elif defined(__clang__)
+#define _PRAGMA_FOR_VECTOR_LOOP_ _Pragma("clang loop vectorize(enable)")
 #elif defined(__GNUC__) || defined(__GNUG__)
 #define _PRAGMA_FOR_VECTOR_LOOP_ _Pragma("GCC ivdep")
 #else

--- a/test/validation/mod2c_core/cpp/zoidsyn.cpp
+++ b/test/validation/mod2c_core/cpp/zoidsyn.cpp
@@ -31,6 +31,9 @@
  
 #if defined(_OPENACC) && !defined(DISABLE_OPENACC)
 #include <openacc.h>
+#if defined(__PGI)
+#include "accelmath.h"
+#endif
 #if defined(PG_ACC_BUGS)
 #define _PRAGMA_FOR_INIT_ACC_LOOP_ _Pragma("acc parallel loop present(_ni[0:_cntml_actual], _nt_data[0:_nt->_ndata], _p[0:_cntml_padded*_psize], _ppvar[0:_cntml_padded*_ppsize], _vec_v[0:_nt->end], nrn_ion_global_map[0:nrn_ion_global_map_size][0:3], _nt[0:1] _thread_present_) if(_nt->compute_gpu)")
 #else
@@ -48,9 +51,7 @@
 #define _PRAGMA_FOR_NETRECV_ACC_LOOP_ _Pragma("")
 #endif
  
-#if defined(__clang__)
-#define _PRAGMA_FOR_VECTOR_LOOP_ _Pragma("clang loop vectorize(enable)")
-#elif defined(__ICC) || defined(__INTEL_COMPILER)
+#if defined(__ICC) || defined(__INTEL_COMPILER)
 #define _PRAGMA_FOR_VECTOR_LOOP_ _Pragma("ivdep")
 #elif defined(__IBMC__) || defined(__IBMCPP__)
 #define _PRAGMA_FOR_VECTOR_LOOP_ _Pragma("ibm independent_loop")
@@ -58,6 +59,8 @@
 #define _PRAGMA_FOR_VECTOR_LOOP_ _Pragma("vector")
 #elif defined(_CRAYC)
 #define _PRAGMA_FOR_VECTOR_LOOP_ _Pragma("_CRI ivdep")
+#elif defined(__clang__)
+#define _PRAGMA_FOR_VECTOR_LOOP_ _Pragma("clang loop vectorize(enable)")
 #elif defined(__GNUC__) || defined(__GNUG__)
 #define _PRAGMA_FOR_VECTOR_LOOP_ _Pragma("GCC ivdep")
 #else


### PR DESCRIPTION
 - On OS X Intel compiler also defines `__clang__` macro
 - If clang pragma is used instead of Intel's `#pragma ivdep`
   then loop is not vectorized.
 - To avoid this, intel, pgi, cray pragma's are inserted before clang & gcc