### PR TITLE
NetSendBuffer_t can now be dynamically grown

### DIFF
--- a/src/mod2c_core/nocpout.c
+++ b/src/mod2c_core/nocpout.c
@@ -3040,6 +3040,12 @@ sprintf(buf, "\
 \n  #pragma acc atomic capture\
 \n  _i = _nsb->_cnt++;\
 \n  if (_i >= _nsb->_size) {\
+\n#if defined(_OPENACC)\
+\n    int NetSendBuffer_t_not_large_enough = 0;\
+\n    assert(NetSendBuffer_t_not_large_enough);\
+\n#else\
+\n    _nsb->grow();\
+\n#endif\
 \n  }\
 \n  _nsb->_sendtype[_i] = _sendtype;\
 \n  _nsb->_vdata_index[_i] = _i_vdata;\

--- a/test/validation/mod2c_core/cpp/SynNMDA10_2_2.cpp
+++ b/test/validation/mod2c_core/cpp/SynNMDA10_2_2.cpp
@@ -654,6 +654,12 @@ static void _net_send_buffering(NetSendBuffer_t* _nsb, int _sendtype, int _i_vda
   #pragma acc atomic capture
   _i = _nsb->_cnt++;
   if (_i >= _nsb->_size) {
+#if defined(_OPENACC)
+    int NetSendBuffer_t_not_large_enough = 0;
+    assert(NetSendBuffer_t_not_large_enough);
+#else
+    _nsb->grow();
+#endif
   }
   _nsb->_sendtype[_i] = _sendtype;
   _nsb->_vdata_index[_i] = _i_vdata;

--- a/test/validation/mod2c_core/cpp/SynNMDA16_2.cpp
+++ b/test/validation/mod2c_core/cpp/SynNMDA16_2.cpp
@@ -950,6 +950,12 @@ static void _net_send_buffering(NetSendBuffer_t* _nsb, int _sendtype, int _i_vda
   #pragma acc atomic capture
   _i = _nsb->_cnt++;
   if (_i >= _nsb->_size) {
+#if defined(_OPENACC)
+    int NetSendBuffer_t_not_large_enough = 0;
+    assert(NetSendBuffer_t_not_large_enough);
+#else
+    _nsb->grow();
+#endif
   }
   _nsb->_sendtype[_i] = _sendtype;
   _nsb->_vdata_index[_i] = _i_vdata;

--- a/test/validation/mod2c_core/cpp/zoidsyn.cpp
+++ b/test/validation/mod2c_core/cpp/zoidsyn.cpp
@@ -389,6 +389,12 @@ static void _net_send_buffering(NetSendBuffer_t* _nsb, int _sendtype, int _i_vda
   #pragma acc atomic capture
   _i = _nsb->_cnt++;
   if (_i >= _nsb->_size) {
+#if defined(_OPENACC)
+    int NetSendBuffer_t_not_large_enough = 0;
+    assert(NetSendBuffer_t_not_large_enough);
+#else
+    _nsb->grow();
+#endif
   }
   _nsb->_sendtype[_i] = _sendtype;
   _nsb->_vdata_index[_i] = _i_vdata;


### PR DESCRIPTION
This only works on CPU, so we throw an error (via assert) for OpenACC.
Updated tests accordingly