### PR TITLE
Build mod2c_core with dbeug flags

### DIFF
--- a/src/mod2c_core/CMakeLists.txt
+++ b/src/mod2c_core/CMakeLists.txt
@@ -60,5 +60,11 @@ add_executable(mod2c_core
     ${BISON_diffeq_OUTPUTS} ${BISON_parse1_OUTPUTS}
     ${FLEX_lex_OUTPUTS})
 
+# as mod2c is typically executed on front-end node, in order to avoid runtime
+# issues from platform specific optimisations, build mod2c with debug flags
+# as performance is not a concern (for translating mod files to cpp)
+separate_arguments(NMODL_C_FLAGS UNIX_COMMAND "${CMAKE_C_FLAGS_DEBUG}")
+target_compile_options(mod2c_core PRIVATE ${NMODL_C_FLAGS})
+
 install(TARGETS mod2c_core DESTINATION bin)
 


### PR DESCRIPTION
 - mod2c_core binary is often used on the login/front-end/build node
   which could be different than compute node cpu type.
 - if we build with O2,O3 or compiler flags of CoreNEURON then this
   could generate binary that doesnt run on front-end node.
 - to avoid this, use debug flags to build mod2c binary as performance
   is not a concern with this specific binary