### PR TITLE
Abort when mod file is not thread safe

### DIFF
--- a/src/mod2c_core/noccout.c
+++ b/src/mod2c_core/noccout.c
@@ -25,6 +25,8 @@ CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 THE POSSIBILITY OF SUCH DAMAGE.
 */
+#include <stdlib.h>
+
 #include "nmodlconf.h"
 
 /* print the .c file from the lists */
@@ -35,6 +37,7 @@ THE POSSIBILITY OF SUCH DAMAGE.
 #define CACHEVEC 1
 
 extern char* nmodl_version_;
+extern char* finname;
 
 #define P(arg) fputs(arg, fcout)
 List           *procfunc, *initfunc, *modelfunc, *termfunc, *initlist, *firstlist;
@@ -202,6 +205,9 @@ void c_out()
 	}
 #endif
 #if VECTORIZE
+    fprintf(stderr, "Error : %s is not thread safe and incompatible with CoreNEURON\n"
+                    "See details at https://neuron.yale.edu/neuron/docs/multithread-parallelization", finname);
+    abort();
 	P("/* NOT VECTORIZED */\n");
 #endif
 	Fflush(fcout);

--- a/test/validation/mod/Nap.mod
+++ b/test/validation/mod/Nap.mod
@@ -5,7 +5,7 @@ NEURON {
 	SUFFIX nap
 	USEION na READ ena WRITE ina
 	RANGE  gbar, timestauh, timestaum, shifttaum, shifttauh, thegna
-	GLOBAL minf, mtau 
+	RANGE minf, mtau
 	:, hinf, mtau, htau
 }
 

--- a/test/validation/mod/NapIn.mod
+++ b/test/validation/mod/NapIn.mod
@@ -4,7 +4,7 @@ NEURON {
 	SUFFIX napIn
 	USEION na READ ena WRITE ina
 	RANGE  gbar, thegna, htau
-	GLOBAL minf, mtau, hinf
+	RANGE minf, mtau, hinf
 }
 
 PARAMETER {

--- a/test/validation/mod/SynNMDA10_1.mod
+++ b/test/validation/mod/SynNMDA10_1.mod
@@ -73,9 +73,10 @@ NEURON {
 	RANGE T_max, T, tau, tRel, Erev, synon
 	RANGE U, Cl, D1, D2, O, UMg, ClMg, D1Mg, D2Mg, OMg
 	RANGE g, gmax, rb, rmb, rmu, rbMg,rmc1b,rmc1u,rmc2b,rmc2u
+    RANGE rmd1b,rmd1u,rmd2b,rmd2u
 	GLOBAL mg, Rb, Ru, Rd1, Rr1, Rd2, Rr2, Ro, Rc, Rmb, Rmu
 	GLOBAL RbMg, RuMg, Rd1Mg, Rr1Mg, Rd2Mg, Rr2Mg, RoMg, RcMg
-	GLOBAL Rmd1b,Rmd1u,Rmd2b,Rmd2u,rmd1b,rmd1u,rmd2b,rmd2u
+	GLOBAL Rmd1b,Rmd1u,Rmd2b,Rmd2u
 	GLOBAL Rmc1b,Rmc1u,Rmc2b,Rmc2u
 	GLOBAL valence, memb_fraction
 	NONSPECIFIC_CURRENT i

--- a/test/validation/mod/SynNMDA10_2.mod
+++ b/test/validation/mod/SynNMDA10_2.mod
@@ -58,6 +58,7 @@ NEURON {
 	RANGE T_max, T, tau, tRel, Erev, synon
 	GLOBAL mg, Rb, Ru, Rd, Rr, Ro, Rc
 	NONSPECIFIC_CURRENT i
+    THREADSAFE
 }
 
 UNITS {

--- a/test/validation/mod2c_core/cpp/Nap.cpp
+++ b/test/validation/mod2c_core/cpp/Nap.cpp
@@ -1,5 +1,5 @@
 /* Created by Language version: 6.2.0 */
-/* NOT VECTORIZED */
+/* VECTORIZED */
 #include <stdio.h>
 #include <stdlib.h>
 #include <math.h>
@@ -27,9 +27,51 @@
 #endif
  namespace coreneuron {
  
-#undef LAYOUT
+#define _thread_present_ /**/ , _slist1[0:1], _dlist1[0:1] 
+ 
+#if defined(_OPENACC) && !defined(DISABLE_OPENACC)
+#include <openacc.h>
+#if defined(__PGI)
+#include "accelmath.h"
+#endif
+#define _PRAGMA_FOR_INIT_ACC_LOOP_ _Pragma("acc parallel loop present(_ni[0:_cntml_actual], _nt_data[0:_nt->_ndata], _p[0:_cntml_padded*_psize], _ppvar[0:_cntml_padded*_ppsize], _vec_v[0:_nt->end], nrn_ion_global_map[0:nrn_ion_global_map_size][0:ion_global_map_member_size], _nt[0:1] _thread_present_) if(_nt->compute_gpu)")
+#define _PRAGMA_FOR_STATE_ACC_LOOP_ _Pragma("acc parallel loop present(_ni[0:_cntml_actual], _nt_data[0:_nt->_ndata], _p[0:_cntml_padded*_psize], _ppvar[0:_cntml_padded*_ppsize], _vec_v[0:_nt->end], _nt[0:1], _ml[0:1] _thread_present_) if(_nt->compute_gpu) async(stream_id)")
+#define _PRAGMA_FOR_CUR_ACC_LOOP_ _Pragma("acc parallel loop present(_ni[0:_cntml_actual], _nt_data[0:_nt->_ndata], _p[0:_cntml_padded*_psize], _ppvar[0:_cntml_padded*_ppsize], _vec_v[0:_nt->end], _vec_d[0:_nt->end], _vec_rhs[0:_nt->end], _nt[0:1] _thread_present_) if(_nt->compute_gpu) async(stream_id)")
+#define _PRAGMA_FOR_CUR_SYN_ACC_LOOP_ _Pragma("acc parallel loop present(_ni[0:_cntml_actual], _nt_data[0:_nt->_ndata], _p[0:_cntml_padded*_psize], _ppvar[0:_cntml_padded*_ppsize], _vec_v[0:_nt->end], _vec_shadow_rhs[0:_nt->shadow_rhs_cnt], _vec_shadow_d[0:_nt->shadow_rhs_cnt], _vec_d[0:_nt->end], _vec_rhs[0:_nt->end], _nt[0:1]) if(_nt->compute_gpu) async(stream_id)")
+#define _PRAGMA_FOR_NETRECV_ACC_LOOP_ _Pragma("acc parallel loop present(_pnt[0:_pnt_length], _nrb[0:1], _nt[0:1], nrn_threads[0:nrn_nthread]) if(_nt->compute_gpu) async(stream_id)")
+#else
+#define _PRAGMA_FOR_INIT_ACC_LOOP_ _Pragma("")
+#define _PRAGMA_FOR_STATE_ACC_LOOP_ _Pragma("")
+#define _PRAGMA_FOR_CUR_ACC_LOOP_ _Pragma("")
+#define _PRAGMA_FOR_CUR_SYN_ACC_LOOP_ _Pragma("")
+#define _PRAGMA_FOR_NETRECV_ACC_LOOP_ _Pragma("")
+#endif
+ 
+#if defined(__ICC) || defined(__INTEL_COMPILER)
+#define _PRAGMA_FOR_VECTOR_LOOP_ _Pragma("ivdep")
+#elif defined(__IBMC__) || defined(__IBMCPP__)
+#define _PRAGMA_FOR_VECTOR_LOOP_ _Pragma("ibm independent_loop")
+#elif defined(__PGI)
+#define _PRAGMA_FOR_VECTOR_LOOP_ _Pragma("vector")
+#elif defined(_CRAYC)
+#define _PRAGMA_FOR_VECTOR_LOOP_ _Pragma("_CRI ivdep")
+#elif defined(__clang__)
+#define _PRAGMA_FOR_VECTOR_LOOP_ _Pragma("clang loop vectorize(enable)")
+#elif defined(__GNUC__) || defined(__GNUG__)
+#define _PRAGMA_FOR_VECTOR_LOOP_ _Pragma("GCC ivdep")
+#else
+#define _PRAGMA_FOR_VECTOR_LOOP_
+#endif // _PRAGMA_FOR_VECTOR_LOOP_
+ 
+#if !defined(LAYOUT)
+/* 1 means AoS, >1 means AoSoA, <= 0 means SOA */
 #define LAYOUT 1
-#define _STRIDE 1
+#endif
+#if LAYOUT >= 1
+#define _STRIDE LAYOUT
+#else
+#define _STRIDE _cntml_padded + _iml
+#endif
  
 #define nrn_init _nrn_init__nap
 #define nrn_cur _nrn_cur__nap
@@ -50,29 +92,43 @@
 #undef _threadargs_
 #undef _threadargsproto_
  
-#define _threadargscomma_ /**/
-#define _threadargsprotocomma_ /**/
-#define _threadargs_ /**/
-#define _threadargsproto_ /**/
+#define _threadargscomma_ _iml, _cntml_padded, _p, _ppvar, _thread, _nt, v,
+#define _threadargsprotocomma_ int _iml, int _cntml_padded, double* _p, Datum* _ppvar, ThreadDatum* _thread, NrnThread* _nt, double v,
+#define _threadargs_ _iml, _cntml_padded, _p, _ppvar, _thread, _nt, v
+#define _threadargsproto_ int _iml, int _cntml_padded, double* _p, Datum* _ppvar, ThreadDatum* _thread, NrnThread* _nt, double v
  	/*SUPPRESS 761*/
 	/*SUPPRESS 762*/
 	/*SUPPRESS 763*/
 	/*SUPPRESS 765*/
-	 static double *_p; static Datum *_ppvar;
+	 /* Thread safe. No static _p or _ppvar. */
  
-#define t nrn_threads->_t
-#define dt nrn_threads->_dt
+#define t _nt->_t
+#define dt _nt->_dt
 #define gbar _p[0*_STRIDE]
 #define timestauh _p[1*_STRIDE]
 #define timestaum _p[2*_STRIDE]
 #define shifttaum _p[3*_STRIDE]
 #define shifttauh _p[4*_STRIDE]
 #define thegna _p[5*_STRIDE]
-#define m _p[6*_STRIDE]
-#define ena _p[7*_STRIDE]
-#define ina _p[8*_STRIDE]
-#define Dm _p[9*_STRIDE]
-#define _g _p[10*_STRIDE]
+#define minf _p[6*_STRIDE]
+#define mtau _p[7*_STRIDE]
+#define m _p[8*_STRIDE]
+#define ena _p[9*_STRIDE]
+#define ina _p[10*_STRIDE]
+#define Dm _p[11*_STRIDE]
+#define _v_unused _p[12*_STRIDE]
+#define _g_unused _p[13*_STRIDE]
+ 
+#ifndef NRN_PRCELLSTATE
+#define NRN_PRCELLSTATE 0
+#endif
+#if NRN_PRCELLSTATE
+#define _PRCELLSTATE_V _v_unused = _v;
+#define _PRCELLSTATE_G _g_unused = _g;
+#else
+#define _PRCELLSTATE_V /**/
+#define _PRCELLSTATE_G /**/
+#endif
 #define _ion_ena		_nt_data[_ppvar[0*_STRIDE]]
 #define _ion_ina	_nt_data[_ppvar[1*_STRIDE]]
 #define _ion_dinadv	_nt_data[_ppvar[2*_STRIDE]]
@@ -86,6 +142,7 @@
 #endif
 #endif
  static int hoc_nrnpointerindex =  -1;
+ static ThreadDatum* _extcall_thread;
  /* external NEURON variables */
  extern double celsius;
  #define _celsius_ _celsius__nap
@@ -112,17 +169,9 @@ double _celsius_;
 #define eNa eNa_nap
  double eNa = 55;
  #pragma acc declare copyin (eNa)
-#define mtau mtau_nap
- double mtau = 0;
- #pragma acc declare copyin (mtau)
-#define minf minf_nap
- double minf = 0;
- #pragma acc declare copyin (minf)
  
 static void _acc_globals_update() {
  #pragma acc update device (eNa) if(nrn_threads->compute_gpu)
- #pragma acc update device (mtau) if(nrn_threads->compute_gpu)
- #pragma acc update device (minf) if(nrn_threads->compute_gpu)
  _celsius_ = celsius;
  #pragma acc update device(_celsius_)
  }
@@ -136,9 +185,9 @@ static void _acc_globals_update() {
 };
  static HocParmUnits _hoc_parm_units[] = {
  "eNa_nap", "mV",
- "mtau_nap", "ms",
  "gbar_nap", "mho/cm2",
  "thegna_nap", "mho/cm2",
+ "mtau_nap", "ms",
  0,0
 };
  
@@ -147,13 +196,9 @@ static void _acc_globals_update() {
 #pragma acc declare copyin(delta_t)
  static double m0 = 0;
 #pragma acc declare copyin(m0)
- static double v = 0;
-#pragma acc declare copyin(v)
  /* connect global user variables to hoc */
  static DoubScal hoc_scdoub[] = {
  "eNa_nap", &eNa_nap,
- "minf_nap", &minf_nap,
- "mtau_nap", &mtau_nap,
  0,0
 };
  static DoubVec hoc_vdoub[] = {
@@ -164,7 +209,6 @@ static void _acc_globals_update() {
 void nrn_init(NrnThread*, Memb_list*, int);
 void nrn_state(NrnThread*, Memb_list*, int);
  void nrn_cur(NrnThread*, Memb_list*, int);
- void nrn_jacob(NrnThread*, Memb_list*, int);
  /* connect range variables in _p that hoc is supposed to know about */
  static const char *_mechanism[] = {
  "6.2.0",
@@ -176,6 +220,8 @@ void nrn_state(NrnThread*, Memb_list*, int);
  "shifttauh_nap",
  0,
  "thegna_nap",
+ "minf_nap",
+ "mtau_nap",
  0,
  "m_nap",
  0,
@@ -203,10 +249,10 @@ static void nrn_alloc(double* _p, Datum* _ppvar, int _type) {
  static void _initlists();
  static void _update_ion_pointer(Datum*);
  
-#define _psize 11
+#define _psize 14
 #define _ppsize 3
  void _Nap_reg() {
-	int _vectorized = 0;
+	int _vectorized = 1;
   _initlists();
  _mechtype = nrn_get_mechtype(_mechanism[1]);
  if (_mechtype == -1) return;
@@ -217,21 +263,20 @@ static void nrn_alloc(double* _p, Datum* _ppvar, int _type) {
  	_na_sym = hoc_lookup("na_ion");
  
 #endif /*BBCORE*/
- 	register_mech(_mechanism, nrn_alloc,nrn_cur, nrn_jacob, nrn_state, nrn_init, hoc_nrnpointerindex, 0);
+ 	register_mech(_mechanism, nrn_alloc,nrn_cur, NULL, nrn_state, nrn_init, hoc_nrnpointerindex, 1);
   hoc_register_prop_size(_mechtype, _psize, _ppsize);
   hoc_register_dparam_semantics(_mechtype, 0, "na_ion");
   hoc_register_dparam_semantics(_mechtype, 1, "na_ion");
   hoc_register_dparam_semantics(_mechtype, 2, "na_ion");
  	hoc_register_var(hoc_scdoub, hoc_vdoub, NULL);
  }
-static int _reset;
 static const char *modelname = "nap";
 
 static int error;
 static int _ninits = 0;
 static int _match_recurse=1;
 static void _modl_cleanup(){ _match_recurse=1;}
-static inline int trates(double);
+static inline int trates(_threadargsprotocomma_ double);
  
 static int _ode_spec1(_threadargsproto_);
 /*static int _ode_matsol1(_threadargsproto_);*/
@@ -246,23 +291,21 @@ int* _dlist1;
  static inline int states(_threadargsproto_);
  
 /*CVODE*/
- static int _ode_spec1 () {_reset=0;
- {
+ static int _ode_spec1 (_threadargsproto_) {int _reset = 0; {
    mtau = 1.0 ;
    minf = ( 1.0 / ( 1.0 + exp ( - ( v + 52.3 ) / 6.8 ) ) ) ;
    Dm = ( minf - m ) / mtau ;
    }
  return _reset;
 }
- static int _ode_matsol1 () {
+ static int _ode_matsol1 (_threadargsproto_) {
  mtau = 1.0 ;
  minf = ( 1.0 / ( 1.0 + exp ( - ( v + 52.3 ) / 6.8 ) ) ) ;
  Dm = Dm  / (1. - dt*( ( ( ( - 1.0 ) ) ) / mtau )) ;
  return 0;
 }
  /*END CVODE*/
- static int states () {_reset=0;
- {
+ static int states (_threadargsproto_) { {
    mtau = 1.0 ;
    minf = ( 1.0 / ( 1.0 + exp ( - ( v + 52.3 ) / 6.8 ) ) ) ;
     m = m + (1. - exp(dt*(( ( ( - 1.0 ) ) ) / mtau)))*(- ( ( ( minf ) ) / mtau ) / ( ( ( ( - 1.0) ) ) / mtau ) - m) ;
@@ -270,15 +313,19 @@ int* _dlist1;
   return 0;
 }
  
-static int  trates (  double _lvm ) {
+static int  trates ( _threadargsprotocomma_ double _lvm ) {
     return 0; }
  
 #if 0 /*BBCORE*/
  
 static void _hoc_trates(void) {
   double _r;
-   _r = 1.;
- trates (  *getarg(1) ;
+   double* _p; Datum* _ppvar; ThreadDatum* _thread; NrnThread* _nt;
+   if (_extcall_prop) {_p = _extcall_prop->param; _ppvar = _extcall_prop->dparam;}else{ _p = (double*)0; _ppvar = (Datum*)0; }
+  _thread = _extcall_thread;
+  _nt = nrn_threads;
+ _r = 1.;
+ trates ( _threadargs_, *getarg(1) ;
  hoc_retpushx(_r);
 }
  
@@ -286,39 +333,55 @@ static void _hoc_trates(void) {
  static void _update_ion_pointer(Datum* _ppvar) {
  }
 
-static void initmodel() {
-  int _i; double _save;_ninits++;
- _save = t;
- t = 0.0;
-{
+static inline void initmodel(_threadargsproto_) {
+  int _i; double _save;{
   m = m0;
  {
    mtau = 1.0 ;
    minf = ( 1.0 / ( 1.0 + exp ( - ( v + 52.3 ) / 6.8 ) ) ) ;
    m = minf ;
    }
-  _sav_indep = t; t = _save;
-
+ 
 }
 }
 
-static void nrn_init(NrnThread* _nt, Memb_list* _ml, int _type){
-double _v; int* _ni; int _iml, _cntml_padded, _cntml_actual;
-#if CACHEVEC
+void nrn_init(NrnThread* _nt, Memb_list* _ml, int _type){
+double* _p; Datum* _ppvar; ThreadDatum* _thread;
+double _v, v; int* _ni; int _iml, _cntml_padded, _cntml_actual;
     _ni = _ml->_nodeindices;
-#endif
 _cntml_actual = _ml->_nodecount;
 _cntml_padded = _ml->_nodecount_padded;
+_thread = _ml->_thread;
+_acc_globals_update();
+double * _nt_data = _nt->_data;
+double * _vec_v = _nt->_actual_v;
+int stream_id = _nt->stream_id;
+  if (_nrn_skip_initmodel == 0) {
+#if LAYOUT == 1 /*AoS*/
 for (_iml = 0; _iml < _cntml_actual; ++_iml) {
  _p = _ml->_data + _iml*_psize; _ppvar = _ml->_pdata + _iml*_ppsize;
+#elif LAYOUT == 0 /*SoA*/
+ _p = _ml->_data; _ppvar = _ml->_pdata;
+/* insert compiler dependent ivdep like pragma */
+_PRAGMA_FOR_VECTOR_LOOP_
+_PRAGMA_FOR_INIT_ACC_LOOP_
+for (_iml = 0; _iml < _cntml_actual; ++_iml) {
+#else /* LAYOUT > 1 */ /*AoSoA*/
+#error AoSoA not implemented.
+for (;;) { /* help clang-format properly indent */
+#endif
+    int _nd_idx = _ni[_iml];
     _v = _vec_v[_nd_idx];
     _PRCELLSTATE_V
  v = _v;
+ _PRCELLSTATE_V
   ena = _ion_ena;
- initmodel();
- }}
+ initmodel(_threadargs_);
+ }
+  }
+}
 
-static double _nrn_current(double _v){double _current=0.;v=_v;{ {
+static double _nrn_current(_threadargsproto_, double _v){double _current=0.;v=_v;{ {
    mtau = 1.0 ;
    minf = ( 1.0 / ( 1.0 + exp ( - ( v + 52.3 ) / 6.8 ) ) ) ;
    thegna = gbar * m ;
@@ -329,67 +392,112 @@ static double _nrn_current(double _v){double _current=0.;v=_v;{ {
 } return _current;
 }
 
-static void nrn_cur(NrnThread* _nt, Memb_list* _ml, int _type){
-int* _ni; double _rhs, _v; int _iml, _cntml_padded, _cntml_actual;
-#if CACHEVEC
-    _ni = _ml->_nodeindices;
+#if defined(ENABLE_CUDA_INTERFACE) && defined(_OPENACC)
+  void nrn_state_launcher(NrnThread*, Memb_list*, int, int);
+  void nrn_jacob_launcher(NrnThread*, Memb_list*, int, int);
+  void nrn_cur_launcher(NrnThread*, Memb_list*, int, int);
 #endif
+
+
+void nrn_cur(NrnThread* _nt, Memb_list* _ml, int _type) {
+double* _p; Datum* _ppvar; ThreadDatum* _thread;
+int* _ni; double _rhs, _g, _v, v; int _iml, _cntml_padded, _cntml_actual;
+    _ni = _ml->_nodeindices;
 _cntml_actual = _ml->_nodecount;
 _cntml_padded = _ml->_nodecount_padded;
+_thread = _ml->_thread;
+double * _vec_rhs = _nt->_actual_rhs;
+double * _vec_d = _nt->_actual_d;
+
+#if defined(ENABLE_CUDA_INTERFACE) && defined(_OPENACC) && !defined(DISABLE_OPENACC)
+  NrnThread* d_nt = acc_deviceptr(_nt);
+  Memb_list* d_ml = acc_deviceptr(_ml);
+  nrn_cur_launcher(d_nt, d_ml, _type, _cntml_actual);
+  return;
+#endif
+
+double * _nt_data = _nt->_data;
+double * _vec_v = _nt->_actual_v;
+int stream_id = _nt->stream_id;
+#if LAYOUT == 1 /*AoS*/
 for (_iml = 0; _iml < _cntml_actual; ++_iml) {
  _p = _ml->_data + _iml*_psize; _ppvar = _ml->_pdata + _iml*_ppsize;
+#elif LAYOUT == 0 /*SoA*/
+ _p = _ml->_data; _ppvar = _ml->_pdata;
+/* insert compiler dependent ivdep like pragma */
+_PRAGMA_FOR_VECTOR_LOOP_
+_PRAGMA_FOR_CUR_ACC_LOOP_
+for (_iml = 0; _iml < _cntml_actual; ++_iml) {
+#else /* LAYOUT > 1 */ /*AoSoA*/
+#error AoSoA not implemented.
+for (;;) { /* help clang-format properly indent */
+#endif
+    int _nd_idx = _ni[_iml];
     _v = _vec_v[_nd_idx];
     _PRCELLSTATE_V
   ena = _ion_ena;
- _g = _nrn_current(_v + .001);
+ _g = _nrn_current(_threadargs_, _v + .001);
  	{ double _dina;
   _dina = ina;
- _rhs = _nrn_current(_v);
+ _rhs = _nrn_current(_threadargs_, _v);
   _ion_dinadv += (_dina - ina)/.001 ;
  	}
  _g = (_g - _rhs)/.001;
   _ion_ina += ina ;
-	VEC_RHS(_ni[_iml]) -= _rhs;
+ _PRCELLSTATE_G
+	_vec_rhs[_nd_idx] -= _rhs;
+	_vec_d[_nd_idx] += _g;
  
-}}
+}
+ 
+}
 
-static void nrn_jacob(NrnThread* _nt, Memb_list* _ml, int _type){
-int* _ni; int _iml, _cntml_padded, _cntml_actual;
-#if CACHEVEC
+void nrn_state(NrnThread* _nt, Memb_list* _ml, int _type) {
+double* _p; Datum* _ppvar; ThreadDatum* _thread;
+double v, _v = 0.0; int* _ni; int _iml, _cntml_padded, _cntml_actual;
     _ni = _ml->_nodeindices;
-#endif
 _cntml_actual = _ml->_nodecount;
 _cntml_padded = _ml->_nodecount_padded;
-for (_iml = 0; _iml < _cntml_actual; ++_iml) {
- _p = _ml->_data + _iml*_psize;
-	VEC_D(_ni[_iml]) += _g;
- 
-}}
+_thread = _ml->_thread;
 
-static void nrn_state(NrnThread* _nt, Memb_list* _ml, int _type){
-double _v = 0.0; int* _ni; int _iml, _cntml_padded, _cntml_actual;
-#if CACHEVEC
-    _ni = _ml->_nodeindices;
+#if defined(ENABLE_CUDA_INTERFACE) && defined(_OPENACC) && !defined(DISABLE_OPENACC)
+  NrnThread* d_nt = acc_deviceptr(_nt);
+  Memb_list* d_ml = acc_deviceptr(_ml);
+  nrn_state_launcher(d_nt, d_ml, _type, _cntml_actual);
+  return;
 #endif
-_cntml_actual = _ml->_nodecount;
-_cntml_padded = _ml->_nodecount_padded;
+
+double * _nt_data = _nt->_data;
+double * _vec_v = _nt->_actual_v;
+int stream_id = _nt->stream_id;
+#if LAYOUT == 1 /*AoS*/
 for (_iml = 0; _iml < _cntml_actual; ++_iml) {
  _p = _ml->_data + _iml*_psize; _ppvar = _ml->_pdata + _iml*_ppsize;
+#elif LAYOUT == 0 /*SoA*/
+ _p = _ml->_data; _ppvar = _ml->_pdata;
+/* insert compiler dependent ivdep like pragma */
+_PRAGMA_FOR_VECTOR_LOOP_
+_PRAGMA_FOR_STATE_ACC_LOOP_
+for (_iml = 0; _iml < _cntml_actual; ++_iml) {
+#else /* LAYOUT > 1 */ /*AoSoA*/
+#error AoSoA not implemented.
+for (;;) { /* help clang-format properly indent */
+#endif
+    int _nd_idx = _ni[_iml];
     _v = _vec_v[_nd_idx];
     _PRCELLSTATE_V
  v=_v;
- _PRCELLSTATE_V
 {
   ena = _ion_ena;
- { error =  states();
- if(error){fprintf(stderr,"at line 52 in file Nap.mod:\n        SOLVE states METHOD cnexp\n"); nrn_complain(_p); abort_run(error);}
- } }}
+ {   states(_threadargs_);
+  } }}
 
 }
 
 static void terminal(){}
 
-static void _initlists() {
+static void _initlists(){
+ double _x; double* _p = &_x;
  int _i; static int _first = 1;
  int _cntml_actual=1;
  int _cntml_padded=1;
@@ -404,4 +512,4 @@ static void _initlists() {
 
 _first = 0;
 }
- } // namespace coreneuron
+} // namespace coreneuron_lib

--- a/test/validation/mod2c_core/cpp/NapIn.cpp
+++ b/test/validation/mod2c_core/cpp/NapIn.cpp
@@ -1,5 +1,5 @@
 /* Created by Language version: 6.2.0 */
-/* NOT VECTORIZED */
+/* VECTORIZED */
 #include <stdio.h>
 #include <stdlib.h>
 #include <math.h>
@@ -27,9 +27,51 @@
 #endif
  namespace coreneuron {
  
-#undef LAYOUT
+#define _thread_present_ /**/ , _slist1[0:2], _dlist1[0:2] 
+ 
+#if defined(_OPENACC) && !defined(DISABLE_OPENACC)
+#include <openacc.h>
+#if defined(__PGI)
+#include "accelmath.h"
+#endif
+#define _PRAGMA_FOR_INIT_ACC_LOOP_ _Pragma("acc parallel loop present(_ni[0:_cntml_actual], _nt_data[0:_nt->_ndata], _p[0:_cntml_padded*_psize], _ppvar[0:_cntml_padded*_ppsize], _vec_v[0:_nt->end], nrn_ion_global_map[0:nrn_ion_global_map_size][0:ion_global_map_member_size], _nt[0:1] _thread_present_) if(_nt->compute_gpu)")
+#define _PRAGMA_FOR_STATE_ACC_LOOP_ _Pragma("acc parallel loop present(_ni[0:_cntml_actual], _nt_data[0:_nt->_ndata], _p[0:_cntml_padded*_psize], _ppvar[0:_cntml_padded*_ppsize], _vec_v[0:_nt->end], _nt[0:1], _ml[0:1] _thread_present_) if(_nt->compute_gpu) async(stream_id)")
+#define _PRAGMA_FOR_CUR_ACC_LOOP_ _Pragma("acc parallel loop present(_ni[0:_cntml_actual], _nt_data[0:_nt->_ndata], _p[0:_cntml_padded*_psize], _ppvar[0:_cntml_padded*_ppsize], _vec_v[0:_nt->end], _vec_d[0:_nt->end], _vec_rhs[0:_nt->end], _nt[0:1] _thread_present_) if(_nt->compute_gpu) async(stream_id)")
+#define _PRAGMA_FOR_CUR_SYN_ACC_LOOP_ _Pragma("acc parallel loop present(_ni[0:_cntml_actual], _nt_data[0:_nt->_ndata], _p[0:_cntml_padded*_psize], _ppvar[0:_cntml_padded*_ppsize], _vec_v[0:_nt->end], _vec_shadow_rhs[0:_nt->shadow_rhs_cnt], _vec_shadow_d[0:_nt->shadow_rhs_cnt], _vec_d[0:_nt->end], _vec_rhs[0:_nt->end], _nt[0:1]) if(_nt->compute_gpu) async(stream_id)")
+#define _PRAGMA_FOR_NETRECV_ACC_LOOP_ _Pragma("acc parallel loop present(_pnt[0:_pnt_length], _nrb[0:1], _nt[0:1], nrn_threads[0:nrn_nthread]) if(_nt->compute_gpu) async(stream_id)")
+#else
+#define _PRAGMA_FOR_INIT_ACC_LOOP_ _Pragma("")
+#define _PRAGMA_FOR_STATE_ACC_LOOP_ _Pragma("")
+#define _PRAGMA_FOR_CUR_ACC_LOOP_ _Pragma("")
+#define _PRAGMA_FOR_CUR_SYN_ACC_LOOP_ _Pragma("")
+#define _PRAGMA_FOR_NETRECV_ACC_LOOP_ _Pragma("")
+#endif
+ 
+#if defined(__ICC) || defined(__INTEL_COMPILER)
+#define _PRAGMA_FOR_VECTOR_LOOP_ _Pragma("ivdep")
+#elif defined(__IBMC__) || defined(__IBMCPP__)
+#define _PRAGMA_FOR_VECTOR_LOOP_ _Pragma("ibm independent_loop")
+#elif defined(__PGI)
+#define _PRAGMA_FOR_VECTOR_LOOP_ _Pragma("vector")
+#elif defined(_CRAYC)
+#define _PRAGMA_FOR_VECTOR_LOOP_ _Pragma("_CRI ivdep")
+#elif defined(__clang__)
+#define _PRAGMA_FOR_VECTOR_LOOP_ _Pragma("clang loop vectorize(enable)")
+#elif defined(__GNUC__) || defined(__GNUG__)
+#define _PRAGMA_FOR_VECTOR_LOOP_ _Pragma("GCC ivdep")
+#else
+#define _PRAGMA_FOR_VECTOR_LOOP_
+#endif // _PRAGMA_FOR_VECTOR_LOOP_
+ 
+#if !defined(LAYOUT)
+/* 1 means AoS, >1 means AoSoA, <= 0 means SOA */
 #define LAYOUT 1
-#define _STRIDE 1
+#endif
+#if LAYOUT >= 1
+#define _STRIDE LAYOUT
+#else
+#define _STRIDE _cntml_padded + _iml
+#endif
  
 #define nrn_init _nrn_init__napIn
 #define nrn_cur _nrn_cur__napIn
@@ -50,28 +92,43 @@
 #undef _threadargs_
 #undef _threadargsproto_
  
-#define _threadargscomma_ /**/
-#define _threadargsprotocomma_ /**/
-#define _threadargs_ /**/
-#define _threadargsproto_ /**/
+#define _threadargscomma_ _iml, _cntml_padded, _p, _ppvar, _thread, _nt, v,
+#define _threadargsprotocomma_ int _iml, int _cntml_padded, double* _p, Datum* _ppvar, ThreadDatum* _thread, NrnThread* _nt, double v,
+#define _threadargs_ _iml, _cntml_padded, _p, _ppvar, _thread, _nt, v
+#define _threadargsproto_ int _iml, int _cntml_padded, double* _p, Datum* _ppvar, ThreadDatum* _thread, NrnThread* _nt, double v
  	/*SUPPRESS 761*/
 	/*SUPPRESS 762*/
 	/*SUPPRESS 763*/
 	/*SUPPRESS 765*/
-	 static double *_p; static Datum *_ppvar;
+	 /* Thread safe. No static _p or _ppvar. */
  
-#define t nrn_threads->_t
-#define dt nrn_threads->_dt
+#define t _nt->_t
+#define dt _nt->_dt
 #define gbar _p[0*_STRIDE]
 #define htau _p[1*_STRIDE]
 #define thegna _p[2*_STRIDE]
-#define m _p[3*_STRIDE]
-#define h _p[4*_STRIDE]
-#define ena _p[5*_STRIDE]
-#define ina _p[6*_STRIDE]
-#define Dm _p[7*_STRIDE]
-#define Dh _p[8*_STRIDE]
-#define _g _p[9*_STRIDE]
+#define minf _p[3*_STRIDE]
+#define hinf _p[4*_STRIDE]
+#define mtau _p[5*_STRIDE]
+#define m _p[6*_STRIDE]
+#define h _p[7*_STRIDE]
+#define ena _p[8*_STRIDE]
+#define ina _p[9*_STRIDE]
+#define Dm _p[10*_STRIDE]
+#define Dh _p[11*_STRIDE]
+#define _v_unused _p[12*_STRIDE]
+#define _g_unused _p[13*_STRIDE]
+ 
+#ifndef NRN_PRCELLSTATE
+#define NRN_PRCELLSTATE 0
+#endif
+#if NRN_PRCELLSTATE
+#define _PRCELLSTATE_V _v_unused = _v;
+#define _PRCELLSTATE_G _g_unused = _g;
+#else
+#define _PRCELLSTATE_V /**/
+#define _PRCELLSTATE_G /**/
+#endif
 #define _ion_ena		_nt_data[_ppvar[0*_STRIDE]]
 #define _ion_ina	_nt_data[_ppvar[1*_STRIDE]]
 #define _ion_dinadv	_nt_data[_ppvar[2*_STRIDE]]
@@ -85,6 +142,7 @@
 #endif
 #endif
  static int hoc_nrnpointerindex =  -1;
+ static ThreadDatum* _extcall_thread;
  /* external NEURON variables */
  extern double celsius;
  #define _celsius_ _celsius__napIn
@@ -111,21 +169,9 @@ double _celsius_;
 #define eNa eNa_napIn
  double eNa = 55;
  #pragma acc declare copyin (eNa)
-#define hinf hinf_napIn
- double hinf = 0;
- #pragma acc declare copyin (hinf)
-#define mtau mtau_napIn
- double mtau = 0;
- #pragma acc declare copyin (mtau)
-#define minf minf_napIn
- double minf = 0;
- #pragma acc declare copyin (minf)
  
 static void _acc_globals_update() {
  #pragma acc update device (eNa) if(nrn_threads->compute_gpu)
- #pragma acc update device (hinf) if(nrn_threads->compute_gpu)
- #pragma acc update device (mtau) if(nrn_threads->compute_gpu)
- #pragma acc update device (minf) if(nrn_threads->compute_gpu)
  _celsius_ = celsius;
  #pragma acc update device(_celsius_)
  }
@@ -139,10 +185,10 @@ static void _acc_globals_update() {
 };
  static HocParmUnits _hoc_parm_units[] = {
  "eNa_napIn", "mV",
- "mtau_napIn", "ms",
  "gbar_napIn", "mho/cm2",
  "htau_napIn", "ms",
  "thegna_napIn", "mho/cm2",
+ "mtau_napIn", "ms",
  0,0
 };
  
@@ -153,14 +199,9 @@ static void _acc_globals_update() {
 #pragma acc declare copyin(h0)
  static double m0 = 0;
 #pragma acc declare copyin(m0)
- static double v = 0;
-#pragma acc declare copyin(v)
  /* connect global user variables to hoc */
  static DoubScal hoc_scdoub[] = {
  "eNa_napIn", &eNa_napIn,
- "minf_napIn", &minf_napIn,
- "hinf_napIn", &hinf_napIn,
- "mtau_napIn", &mtau_napIn,
  0,0
 };
  static DoubVec hoc_vdoub[] = {
@@ -171,7 +212,6 @@ static void _acc_globals_update() {
 void nrn_init(NrnThread*, Memb_list*, int);
 void nrn_state(NrnThread*, Memb_list*, int);
  void nrn_cur(NrnThread*, Memb_list*, int);
- void nrn_jacob(NrnThread*, Memb_list*, int);
  /* connect range variables in _p that hoc is supposed to know about */
  static const char *_mechanism[] = {
  "6.2.0",
@@ -180,6 +220,9 @@ void nrn_state(NrnThread*, Memb_list*, int);
  "htau_napIn",
  0,
  "thegna_napIn",
+ "minf_napIn",
+ "hinf_napIn",
+ "mtau_napIn",
  0,
  "m_napIn",
  "h_napIn",
@@ -205,10 +248,10 @@ static void nrn_alloc(double* _p, Datum* _ppvar, int _type) {
  static void _initlists();
  static void _update_ion_pointer(Datum*);
  
-#define _psize 10
+#define _psize 14
 #define _ppsize 3
  void _NapIn_reg() {
-	int _vectorized = 0;
+	int _vectorized = 1;
   _initlists();
  _mechtype = nrn_get_mechtype(_mechanism[1]);
  if (_mechtype == -1) return;
@@ -219,21 +262,20 @@ static void nrn_alloc(double* _p, Datum* _ppvar, int _type) {
  	_na_sym = hoc_lookup("na_ion");
  
 #endif /*BBCORE*/
- 	register_mech(_mechanism, nrn_alloc,nrn_cur, nrn_jacob, nrn_state, nrn_init, hoc_nrnpointerindex, 0);
+ 	register_mech(_mechanism, nrn_alloc,nrn_cur, NULL, nrn_state, nrn_init, hoc_nrnpointerindex, 1);
   hoc_register_prop_size(_mechtype, _psize, _ppsize);
   hoc_register_dparam_semantics(_mechtype, 0, "na_ion");
   hoc_register_dparam_semantics(_mechtype, 1, "na_ion");
   hoc_register_dparam_semantics(_mechtype, 2, "na_ion");
  	hoc_register_var(hoc_scdoub, hoc_vdoub, NULL);
  }
-static int _reset;
 static const char *modelname = "nap";
 
 static int error;
 static int _ninits = 0;
 static int _match_recurse=1;
 static void _modl_cleanup(){ _match_recurse=1;}
-static inline int trates(double);
+static inline int trates(_threadargsprotocomma_ double);
  
 static int _ode_spec1(_threadargsproto_);
 /*static int _ode_matsol1(_threadargsproto_);*/
@@ -248,23 +290,21 @@ int* _dlist1;
  static inline int states(_threadargsproto_);
  
 /*CVODE*/
- static int _ode_spec1 () {_reset=0;
- {
+ static int _ode_spec1 (_threadargsproto_) {int _reset = 0; {
    trates ( _threadargscomma_ v ) ;
    Dm = ( minf - m ) / mtau ;
    Dh = ( hinf - h ) / htau ;
    }
  return _reset;
 }
- static int _ode_matsol1 () {
+ static int _ode_matsol1 (_threadargsproto_) {
  trates ( _threadargscomma_ v ) ;
  Dm = Dm  / (1. - dt*( ( ( ( - 1.0 ) ) ) / mtau )) ;
  Dh = Dh  / (1. - dt*( ( ( ( - 1.0 ) ) ) / htau )) ;
  return 0;
 }
  /*END CVODE*/
- static int states () {_reset=0;
- {
+ static int states (_threadargsproto_) { {
    trates ( _threadargscomma_ v ) ;
     m = m + (1. - exp(dt*(( ( ( - 1.0 ) ) ) / mtau)))*(- ( ( ( minf ) ) / mtau ) / ( ( ( ( - 1.0) ) ) / mtau ) - m) ;
     h = h + (1. - exp(dt*(( ( ( - 1.0 ) ) ) / htau)))*(- ( ( ( hinf ) ) / htau ) / ( ( ( ( - 1.0) ) ) / htau ) - h) ;
@@ -272,7 +312,7 @@ int* _dlist1;
   return 0;
 }
  
-static int  trates (  double _lvm ) {
+static int  trates ( _threadargsprotocomma_ double _lvm ) {
    mtau = 1.0 ;
    minf = 1.0 / ( 1.0 + exp ( - ( v + 52.3 ) / 6.8 ) ) ;
    hinf = 1.0 / ( 1.0 + exp ( ( v + 48.0 ) / 10.0 ) ) ;
@@ -282,8 +322,12 @@ static int  trates (  double _lvm ) {
  
 static void _hoc_trates(void) {
   double _r;
-   _r = 1.;
- trates (  *getarg(1) ;
+   double* _p; Datum* _ppvar; ThreadDatum* _thread; NrnThread* _nt;
+   if (_extcall_prop) {_p = _extcall_prop->param; _ppvar = _extcall_prop->dparam;}else{ _p = (double*)0; _ppvar = (Datum*)0; }
+  _thread = _extcall_thread;
+  _nt = nrn_threads;
+ _r = 1.;
+ trates ( _threadargs_, *getarg(1) ;
  hoc_retpushx(_r);
 }
  
@@ -291,11 +335,8 @@ static void _hoc_trates(void) {
  static void _update_ion_pointer(Datum* _ppvar) {
  }
 
-static void initmodel() {
-  int _i; double _save;_ninits++;
- _save = t;
- t = 0.0;
-{
+static inline void initmodel(_threadargsproto_) {
+  int _i; double _save;{
   h = h0;
   m = m0;
  {
@@ -303,28 +344,47 @@ static void initmodel() {
    m = minf ;
    h = hinf ;
    }
-  _sav_indep = t; t = _save;
-
+ 
 }
 }
 
-static void nrn_init(NrnThread* _nt, Memb_list* _ml, int _type){
-double _v; int* _ni; int _iml, _cntml_padded, _cntml_actual;
-#if CACHEVEC
+void nrn_init(NrnThread* _nt, Memb_list* _ml, int _type){
+double* _p; Datum* _ppvar; ThreadDatum* _thread;
+double _v, v; int* _ni; int _iml, _cntml_padded, _cntml_actual;
     _ni = _ml->_nodeindices;
-#endif
 _cntml_actual = _ml->_nodecount;
 _cntml_padded = _ml->_nodecount_padded;
+_thread = _ml->_thread;
+_acc_globals_update();
+double * _nt_data = _nt->_data;
+double * _vec_v = _nt->_actual_v;
+int stream_id = _nt->stream_id;
+  if (_nrn_skip_initmodel == 0) {
+#if LAYOUT == 1 /*AoS*/
 for (_iml = 0; _iml < _cntml_actual; ++_iml) {
  _p = _ml->_data + _iml*_psize; _ppvar = _ml->_pdata + _iml*_ppsize;
+#elif LAYOUT == 0 /*SoA*/
+ _p = _ml->_data; _ppvar = _ml->_pdata;
+/* insert compiler dependent ivdep like pragma */
+_PRAGMA_FOR_VECTOR_LOOP_
+_PRAGMA_FOR_INIT_ACC_LOOP_
+for (_iml = 0; _iml < _cntml_actual; ++_iml) {
+#else /* LAYOUT > 1 */ /*AoSoA*/
+#error AoSoA not implemented.
+for (;;) { /* help clang-format properly indent */
+#endif
+    int _nd_idx = _ni[_iml];
     _v = _vec_v[_nd_idx];
     _PRCELLSTATE_V
  v = _v;
+ _PRCELLSTATE_V
   ena = _ion_ena;
- initmodel();
- }}
+ initmodel(_threadargs_);
+ }
+  }
+}
 
-static double _nrn_current(double _v){double _current=0.;v=_v;{ {
+static double _nrn_current(_threadargsproto_, double _v){double _current=0.;v=_v;{ {
    trates ( _threadargscomma_ v ) ;
    thegna = gbar * m * h ;
    ina = thegna * ( v - eNa ) ;
@@ -334,67 +394,112 @@ static double _nrn_current(double _v){double _current=0.;v=_v;{ {
 } return _current;
 }
 
-static void nrn_cur(NrnThread* _nt, Memb_list* _ml, int _type){
-int* _ni; double _rhs, _v; int _iml, _cntml_padded, _cntml_actual;
-#if CACHEVEC
-    _ni = _ml->_nodeindices;
+#if defined(ENABLE_CUDA_INTERFACE) && defined(_OPENACC)
+  void nrn_state_launcher(NrnThread*, Memb_list*, int, int);
+  void nrn_jacob_launcher(NrnThread*, Memb_list*, int, int);
+  void nrn_cur_launcher(NrnThread*, Memb_list*, int, int);
 #endif
+
+
+void nrn_cur(NrnThread* _nt, Memb_list* _ml, int _type) {
+double* _p; Datum* _ppvar; ThreadDatum* _thread;
+int* _ni; double _rhs, _g, _v, v; int _iml, _cntml_padded, _cntml_actual;
+    _ni = _ml->_nodeindices;
 _cntml_actual = _ml->_nodecount;
 _cntml_padded = _ml->_nodecount_padded;
+_thread = _ml->_thread;
+double * _vec_rhs = _nt->_actual_rhs;
+double * _vec_d = _nt->_actual_d;
+
+#if defined(ENABLE_CUDA_INTERFACE) && defined(_OPENACC) && !defined(DISABLE_OPENACC)
+  NrnThread* d_nt = acc_deviceptr(_nt);
+  Memb_list* d_ml = acc_deviceptr(_ml);
+  nrn_cur_launcher(d_nt, d_ml, _type, _cntml_actual);
+  return;
+#endif
+
+double * _nt_data = _nt->_data;
+double * _vec_v = _nt->_actual_v;
+int stream_id = _nt->stream_id;
+#if LAYOUT == 1 /*AoS*/
 for (_iml = 0; _iml < _cntml_actual; ++_iml) {
  _p = _ml->_data + _iml*_psize; _ppvar = _ml->_pdata + _iml*_ppsize;
+#elif LAYOUT == 0 /*SoA*/
+ _p = _ml->_data; _ppvar = _ml->_pdata;
+/* insert compiler dependent ivdep like pragma */
+_PRAGMA_FOR_VECTOR_LOOP_
+_PRAGMA_FOR_CUR_ACC_LOOP_
+for (_iml = 0; _iml < _cntml_actual; ++_iml) {
+#else /* LAYOUT > 1 */ /*AoSoA*/
+#error AoSoA not implemented.
+for (;;) { /* help clang-format properly indent */
+#endif
+    int _nd_idx = _ni[_iml];
     _v = _vec_v[_nd_idx];
     _PRCELLSTATE_V
   ena = _ion_ena;
- _g = _nrn_current(_v + .001);
+ _g = _nrn_current(_threadargs_, _v + .001);
  	{ double _dina;
   _dina = ina;
- _rhs = _nrn_current(_v);
+ _rhs = _nrn_current(_threadargs_, _v);
   _ion_dinadv += (_dina - ina)/.001 ;
  	}
  _g = (_g - _rhs)/.001;
   _ion_ina += ina ;
-	VEC_RHS(_ni[_iml]) -= _rhs;
+ _PRCELLSTATE_G
+	_vec_rhs[_nd_idx] -= _rhs;
+	_vec_d[_nd_idx] += _g;
  
-}}
+}
+ 
+}
 
-static void nrn_jacob(NrnThread* _nt, Memb_list* _ml, int _type){
-int* _ni; int _iml, _cntml_padded, _cntml_actual;
-#if CACHEVEC
+void nrn_state(NrnThread* _nt, Memb_list* _ml, int _type) {
+double* _p; Datum* _ppvar; ThreadDatum* _thread;
+double v, _v = 0.0; int* _ni; int _iml, _cntml_padded, _cntml_actual;
     _ni = _ml->_nodeindices;
-#endif
 _cntml_actual = _ml->_nodecount;
 _cntml_padded = _ml->_nodecount_padded;
-for (_iml = 0; _iml < _cntml_actual; ++_iml) {
- _p = _ml->_data + _iml*_psize;
-	VEC_D(_ni[_iml]) += _g;
- 
-}}
+_thread = _ml->_thread;
 
-static void nrn_state(NrnThread* _nt, Memb_list* _ml, int _type){
-double _v = 0.0; int* _ni; int _iml, _cntml_padded, _cntml_actual;
-#if CACHEVEC
-    _ni = _ml->_nodeindices;
+#if defined(ENABLE_CUDA_INTERFACE) && defined(_OPENACC) && !defined(DISABLE_OPENACC)
+  NrnThread* d_nt = acc_deviceptr(_nt);
+  Memb_list* d_ml = acc_deviceptr(_ml);
+  nrn_state_launcher(d_nt, d_ml, _type, _cntml_actual);
+  return;
 #endif
-_cntml_actual = _ml->_nodecount;
-_cntml_padded = _ml->_nodecount_padded;
+
+double * _nt_data = _nt->_data;
+double * _vec_v = _nt->_actual_v;
+int stream_id = _nt->stream_id;
+#if LAYOUT == 1 /*AoS*/
 for (_iml = 0; _iml < _cntml_actual; ++_iml) {
  _p = _ml->_data + _iml*_psize; _ppvar = _ml->_pdata + _iml*_ppsize;
+#elif LAYOUT == 0 /*SoA*/
+ _p = _ml->_data; _ppvar = _ml->_pdata;
+/* insert compiler dependent ivdep like pragma */
+_PRAGMA_FOR_VECTOR_LOOP_
+_PRAGMA_FOR_STATE_ACC_LOOP_
+for (_iml = 0; _iml < _cntml_actual; ++_iml) {
+#else /* LAYOUT > 1 */ /*AoSoA*/
+#error AoSoA not implemented.
+for (;;) { /* help clang-format properly indent */
+#endif
+    int _nd_idx = _ni[_iml];
     _v = _vec_v[_nd_idx];
     _PRCELLSTATE_V
  v=_v;
- _PRCELLSTATE_V
 {
   ena = _ion_ena;
- { error =  states();
- if(error){fprintf(stderr,"at line 43 in file NapIn.mod:\n    		\n"); nrn_complain(_p); abort_run(error);}
- } }}
+ {   states(_threadargs_);
+  } }}
 
 }
 
 static void terminal(){}
 
-static void _initlists() {
+static void _initlists(){
+ double _x; double* _p = &_x;
  int _i; static int _first = 1;
  int _cntml_actual=1;
  int _cntml_padded=1;
@@ -410,4 +515,4 @@ static void _initlists() {
 
 _first = 0;
 }
- } // namespace coreneuron
+} // namespace coreneuron_lib

--- a/test/validation/mod2c_core/cpp/SynNMDA10_2.cpp
+++ b/test/validation/mod2c_core/cpp/SynNMDA10_2.cpp
@@ -1,5 +1,5 @@
 /* Created by Language version: 6.2.0 */
-/* NOT VECTORIZED */
+/* VECTORIZED */
 #include <stdio.h>
 #include <stdlib.h>
 #include <math.h>
@@ -27,9 +27,51 @@
 #endif
  namespace coreneuron {
  
-#undef LAYOUT
+#define _thread_present_ /**/ , _thread[0:2] , _slist1[0:10], _dlist1[0:10] 
+ 
+#if defined(_OPENACC) && !defined(DISABLE_OPENACC)
+#include <openacc.h>
+#if defined(__PGI)
+#include "accelmath.h"
+#endif
+#define _PRAGMA_FOR_INIT_ACC_LOOP_ _Pragma("acc parallel loop present(_ni[0:_cntml_actual], _nt_data[0:_nt->_ndata], _p[0:_cntml_padded*_psize], _ppvar[0:_cntml_padded*_ppsize], _vec_v[0:_nt->end], nrn_ion_global_map[0:nrn_ion_global_map_size][0:ion_global_map_member_size], _nt[0:1] _thread_present_) if(_nt->compute_gpu)")
+#define _PRAGMA_FOR_STATE_ACC_LOOP_ _Pragma("acc parallel loop present(_ni[0:_cntml_actual], _nt_data[0:_nt->_ndata], _p[0:_cntml_padded*_psize], _ppvar[0:_cntml_padded*_ppsize], _vec_v[0:_nt->end], _nt[0:1], _ml[0:1] _thread_present_) if(_nt->compute_gpu) async(stream_id)")
+#define _PRAGMA_FOR_CUR_ACC_LOOP_ _Pragma("acc parallel loop present(_ni[0:_cntml_actual], _nt_data[0:_nt->_ndata], _p[0:_cntml_padded*_psize], _ppvar[0:_cntml_padded*_ppsize], _vec_v[0:_nt->end], _vec_d[0:_nt->end], _vec_rhs[0:_nt->end], _nt[0:1] _thread_present_) if(_nt->compute_gpu) async(stream_id)")
+#define _PRAGMA_FOR_CUR_SYN_ACC_LOOP_ _Pragma("acc parallel loop present(_ni[0:_cntml_actual], _nt_data[0:_nt->_ndata], _p[0:_cntml_padded*_psize], _ppvar[0:_cntml_padded*_ppsize], _vec_v[0:_nt->end], _vec_shadow_rhs[0:_nt->shadow_rhs_cnt], _vec_shadow_d[0:_nt->shadow_rhs_cnt], _vec_d[0:_nt->end], _vec_rhs[0:_nt->end], _nt[0:1]) if(_nt->compute_gpu) async(stream_id)")
+#define _PRAGMA_FOR_NETRECV_ACC_LOOP_ _Pragma("acc parallel loop present(_pnt[0:_pnt_length], _nrb[0:1], _nt[0:1], nrn_threads[0:nrn_nthread]) if(_nt->compute_gpu) async(stream_id)")
+#else
+#define _PRAGMA_FOR_INIT_ACC_LOOP_ _Pragma("")
+#define _PRAGMA_FOR_STATE_ACC_LOOP_ _Pragma("")
+#define _PRAGMA_FOR_CUR_ACC_LOOP_ _Pragma("")
+#define _PRAGMA_FOR_CUR_SYN_ACC_LOOP_ _Pragma("")
+#define _PRAGMA_FOR_NETRECV_ACC_LOOP_ _Pragma("")
+#endif
+ 
+#if defined(__ICC) || defined(__INTEL_COMPILER)
+#define _PRAGMA_FOR_VECTOR_LOOP_ _Pragma("ivdep")
+#elif defined(__IBMC__) || defined(__IBMCPP__)
+#define _PRAGMA_FOR_VECTOR_LOOP_ _Pragma("ibm independent_loop")
+#elif defined(__PGI)
+#define _PRAGMA_FOR_VECTOR_LOOP_ _Pragma("vector")
+#elif defined(_CRAYC)
+#define _PRAGMA_FOR_VECTOR_LOOP_ _Pragma("_CRI ivdep")
+#elif defined(__clang__)
+#define _PRAGMA_FOR_VECTOR_LOOP_ _Pragma("clang loop vectorize(enable)")
+#elif defined(__GNUC__) || defined(__GNUG__)
+#define _PRAGMA_FOR_VECTOR_LOOP_ _Pragma("GCC ivdep")
+#else
+#define _PRAGMA_FOR_VECTOR_LOOP_
+#endif // _PRAGMA_FOR_VECTOR_LOOP_
+ 
+#if !defined(LAYOUT)
+/* 1 means AoS, >1 means AoSoA, <= 0 means SOA */
 #define LAYOUT 1
-#define _STRIDE 1
+#endif
+#if LAYOUT >= 1
+#define _STRIDE LAYOUT
+#else
+#define _STRIDE _cntml_padded + _iml
+#endif
  
 
 #if !defined(NET_RECEIVE_BUFFERING)
@@ -61,18 +103,18 @@ void _net_buf_receive(NrnThread*);
 #undef _threadargs_
 #undef _threadargsproto_
  
-#define _threadargscomma_ /**/
-#define _threadargsprotocomma_ /**/
-#define _threadargs_ /**/
-#define _threadargsproto_ /**/
+#define _threadargscomma_ _iml, _cntml_padded, _p, _ppvar, _thread, _nt, v,
+#define _threadargsprotocomma_ int _iml, int _cntml_padded, double* _p, Datum* _ppvar, ThreadDatum* _thread, NrnThread* _nt, double v,
+#define _threadargs_ _iml, _cntml_padded, _p, _ppvar, _thread, _nt, v
+#define _threadargsproto_ int _iml, int _cntml_padded, double* _p, Datum* _ppvar, ThreadDatum* _thread, NrnThread* _nt, double v
  	/*SUPPRESS 761*/
 	/*SUPPRESS 762*/
 	/*SUPPRESS 763*/
 	/*SUPPRESS 765*/
-	 static double *_p; static Datum *_ppvar;
+	 /* Thread safe. No static _p or _ppvar. */
  
-#define t nrn_threads->_t
-#define dt nrn_threads->_dt
+#define t _nt->_t
+#define dt _nt->_dt
 #define Erev _p[0*_STRIDE]
 #define gmax _p[1*_STRIDE]
 #define tau _p[2*_STRIDE]
@@ -107,8 +149,20 @@ void _net_buf_receive(NrnThread*);
 #define DCB2 _p[31*_STRIDE]
 #define DDB _p[32*_STRIDE]
 #define DOB _p[33*_STRIDE]
-#define _g _p[34*_STRIDE]
-#define _tsav _p[35*_STRIDE]
+#define _v_unused _p[34*_STRIDE]
+#define _g_unused _p[35*_STRIDE]
+#define _tsav _p[36*_STRIDE]
+ 
+#ifndef NRN_PRCELLSTATE
+#define NRN_PRCELLSTATE 0
+#endif
+#if NRN_PRCELLSTATE
+#define _PRCELLSTATE_V _v_unused = _v;
+#define _PRCELLSTATE_G _g_unused = _g;
+#else
+#define _PRCELLSTATE_V /**/
+#define _PRCELLSTATE_G /**/
+#endif
 #define _nd_area  _nt_data[_ppvar[0*_STRIDE]]
  
 #if MAC
@@ -120,6 +174,7 @@ void _net_buf_receive(NrnThread*);
 #endif
 #endif
  static int hoc_nrnpointerindex =  -1;
+ static ThreadDatum* _extcall_thread;
  /* external NEURON variables */
  
 #if 0 /*BBCORE*/
@@ -249,8 +304,6 @@ static void _acc_globals_update() {
 #pragma acc declare copyin(O0)
  static double delta_t = 1;
 #pragma acc declare copyin(delta_t)
- static double v = 0;
-#pragma acc declare copyin(v)
  /* connect global user variables to hoc */
  static DoubScal hoc_scdoub[] = {
  "mg_NMDA10_2", &mg_NMDA10_2,
@@ -270,7 +323,6 @@ static void _acc_globals_update() {
 void nrn_init(NrnThread*, Memb_list*, int);
 void nrn_state(NrnThread*, Memb_list*, int);
  void nrn_cur(NrnThread*, Memb_list*, int);
- void nrn_jacob(NrnThread*, Memb_list*, int);
  
 #if 0 /*BBCORE*/
  static void _hoc_destroy_pnt(_vptr) void* _vptr; {
@@ -324,11 +376,12 @@ static void nrn_alloc(double* _p, Datum* _ppvar, int _type) {
 }
  static void _initlists();
  void _net_receive(Point_process*, int, double);
+ static void _thread_cleanup(ThreadDatum*);
  
-#define _psize 36
+#define _psize 37
 #define _ppsize 2
  void _SynNMDA10_2_reg() {
-	int _vectorized = 0;
+	int _vectorized = 1;
   _initlists();
  _mechtype = nrn_get_mechtype(_mechanism[1]);
  if (_mechtype == -1) return;
@@ -338,10 +391,12 @@ static void nrn_alloc(double* _p, Datum* _ppvar, int _type) {
  
 #endif /*BBCORE*/
  	_pointtype = point_register_mech(_mechanism,
-	 nrn_alloc,nrn_cur, nrn_jacob, nrn_state, nrn_init,
+	 nrn_alloc,nrn_cur, NULL, nrn_state, nrn_init,
 	 hoc_nrnpointerindex,
 	 NULL/*_hoc_create_pnt*/, NULL/*_hoc_destroy_pnt*/, /*_member_func,*/
-	 0);
+	 3);
+  _extcall_thread = (ThreadDatum*)ecalloc(2, sizeof(ThreadDatum));
+     _nrn_thread_reg0(_mechtype, _thread_cleanup);
   hoc_register_prop_size(_mechtype, _psize, _ppsize);
   hoc_register_dparam_semantics(_mechtype, 0, "area");
   hoc_register_dparam_semantics(_mechtype, 1, "pntproc");
@@ -352,24 +407,22 @@ static void nrn_alloc(double* _p, Datum* _ppvar, int _type) {
  set_pnt_receive(_mechtype, _net_receive, nullptr, 1);
  	hoc_register_var(hoc_scdoub, hoc_vdoub, NULL);
  }
-static int _reset;
 static const char *modelname = "detailed model of glutamate NMDA receptors";
 
 static int error;
 static int _ninits = 0;
 static int _match_recurse=1;
 static void _modl_cleanup(){ _match_recurse=1;}
-static inline int release(double);
-static inline int rates(double);
+static inline int release(_threadargsprotocomma_ double);
+static inline int rates(_threadargsprotocomma_ double);
  
-#define _MATELM1(_row,_col)	*(_getelm(_row + 1, _col + 1))
+#define _MATELM1(_row,_col) _nrn_thread_getelm((SparseObj*)_so, _row + 1, _col + 1, _iml)[_iml]
  
-#define _RHS1(_arg) _coef1[(_arg + 1)]
- static double *_coef1;
- 
+#define _RHS1(_arg) _rhs[(_arg+1)*_STRIDE]
+  
 #define _linmat1  1
- static void* _sparseobj1;
- static void* _cvsparseobj1;
+ static int _spth1 = 1;
+ static int _cvspth1 = 0;
  
 static int _ode_spec1(_threadargsproto_);
 /*static int _ode_matsol1(_threadargsproto_);*/
@@ -387,8 +440,8 @@ int* _dlist1;
 #define INSIDE_NMODL
 #endif
  
-int kstates ()
- {_reset=0;
+int kstates (void* _so, double* _rhs, _threadargsproto_)
+ {int _reset=0;
  {
    double b_flux, f_flux, _term; int _i;
  {int _i; double _dt1 = 1.0/dt;
@@ -591,7 +644,9 @@ static void _net_receive_kernel(double _nrb_t, Point_process* _pnt, int _weight_
 void _net_receive (Point_process* _pnt, int _weight_index, double _lflag) 
 #endif
  
-{ 
+{  double* _p; Datum* _ppvar; ThreadDatum* _thread; double v = 0;
+   Memb_list* _ml; int _cntml_padded, _cntml_actual; int _iml; double* _args;
+ 
    NrnThread* _nt;
    int _tid = _pnt->_tid; 
    _nt = nrn_threads + _tid;
@@ -627,7 +682,7 @@ void _net_receive (Point_process* _pnt, int _weight_index, double _lflag)
 #endif
  }
  
-static int  release (  double _lt ) {
+static int  release ( _threadargsprotocomma_ double _lt ) {
    T = T_max * ( _lt - tRel ) / tau * exp ( 1.0 - ( _lt - tRel ) / tau ) * synon ;
    
 /*VERBATIM*/
@@ -638,15 +693,19 @@ static int  release (  double _lt ) {
  
 static double _hoc_release(void* _vptr) {
  double _r;
-    _hoc_setdata(_vptr);
+   double* _p; Datum* _ppvar; ThreadDatum* _thread; NrnThread* _nt;
+   _p = ((Point_process*)_vptr)->_prop->param;
+  _ppvar = ((Point_process*)_vptr)->_prop->dparam;
+  _thread = _extcall_thread;
+  _nt = (NrnThread*)((Point_process*)_vptr)->_vnt;
  _r = 1.;
- release (  *getarg(1) );
+ release ( _threadargs_, *getarg(1) );
  return(_r);
 }
  
 #endif /*BBCORE*/
  
-static int  rates (  double _lv ) {
+static int  rates ( _threadargsprotocomma_ double _lv ) {
    RMgB = 610e-3 * exp ( 1.0 * - _lv / 17.0 ) * ( mg / 1.0 ) * 1.0 ;
    RMgU = 5400e-3 * exp ( 1.0 * _lv / 47.0 ) * 1.0 ;
     return 0; }
@@ -655,16 +714,20 @@ static int  rates (  double _lv ) {
  
 static double _hoc_rates(void* _vptr) {
  double _r;
-    _hoc_setdata(_vptr);
+   double* _p; Datum* _ppvar; ThreadDatum* _thread; NrnThread* _nt;
+   _p = ((Point_process*)_vptr)->_prop->param;
+  _ppvar = ((Point_process*)_vptr)->_prop->dparam;
+  _thread = _extcall_thread;
+  _nt = (NrnThread*)((Point_process*)_vptr)->_vnt;
  _r = 1.;
- rates (  *getarg(1) );
+ rates ( _threadargs_, *getarg(1) );
  return(_r);
 }
  
 #endif /*BBCORE*/
  
 /*CVODE ode begin*/
- static int _ode_spec1() {_reset=0;{
+ static int _ode_spec1(_threadargsproto_) {int _reset=0;{
  double b_flux, f_flux, _term; int _i;
  {int _i; for(_i=0;_i<10;_i++) _p[_dlist1[_i]] = 0.0;}
  release ( _threadargscomma_ t ) ;
@@ -739,7 +802,7 @@ static double _hoc_rates(void* _vptr) {
  }
  
 /*CVODE matsol*/
- static int _ode_matsol1() {_reset=0;{
+ static int _ode_matsol1(void* _so, double* _rhs, _threadargsproto_) {int _reset=0;{
  double b_flux, f_flux, _term; int _i;
    b_flux = f_flux = 0.;
  {int _i; double _dt1 = 1.0/dt;
@@ -829,12 +892,14 @@ for(_i=0;_i<10;_i++){
  }
  
 /*CVODE end*/
+ 
+static void _thread_cleanup(ThreadDatum* _thread) {
+   _nrn_destroy_sparseobj_thread((SparseObj*)_thread[_cvspth1]._pvoid);
+   _nrn_destroy_sparseobj_thread((SparseObj*)_thread[_spth1]._pvoid);
+ }
 
-static void initmodel() {
-  int _i; double _save;_ninits++;
- _save = t;
- t = 0.0;
-{
+static inline void initmodel(_threadargsproto_) {
+  int _i; double _save;{
   CB2 = CB20;
   CB1 = CB10;
   CB0 = CB00;
@@ -861,28 +926,57 @@ static void initmodel() {
    DB = 0.0 ;
    OB = 0.0 ;
    }
-  _sav_indep = t; t = _save;
-
+ 
 }
 }
 
-static void nrn_init(NrnThread* _nt, Memb_list* _ml, int _type){
-double _v; int* _ni; int _iml, _cntml_padded, _cntml_actual;
-#if CACHEVEC
+void nrn_init(NrnThread* _nt, Memb_list* _ml, int _type){
+double* _p; Datum* _ppvar; ThreadDatum* _thread;
+double _v, v; int* _ni; int _iml, _cntml_padded, _cntml_actual;
     _ni = _ml->_nodeindices;
-#endif
 _cntml_actual = _ml->_nodecount;
 _cntml_padded = _ml->_nodecount_padded;
+_thread = _ml->_thread;
+  if (!_thread[_spth1]._pvoid) {
+    _thread[_spth1]._pvoid = nrn_cons_sparseobj(_kinetic_kstates_NMDA10_2, 10, _ml, _threadargs_);
+    #ifdef _OPENACC
+    if (_nt->compute_gpu) {
+      void* _d_so = (void*) acc_deviceptr(_thread[_spth1]._pvoid);
+      ThreadDatum* _d_td = (ThreadDatum*)acc_deviceptr(_thread);
+      acc_memcpy_to_device(&(_d_td[_spth1]._pvoid), &_d_so, sizeof(void*));
+    }
+    #endif
+  }
+_acc_globals_update();
+double * _nt_data = _nt->_data;
+double * _vec_v = _nt->_actual_v;
+int stream_id = _nt->stream_id;
+  if (_nrn_skip_initmodel == 0) {
+#if LAYOUT == 1 /*AoS*/
 for (_iml = 0; _iml < _cntml_actual; ++_iml) {
  _p = _ml->_data + _iml*_psize; _ppvar = _ml->_pdata + _iml*_ppsize;
+#elif LAYOUT == 0 /*SoA*/
+ _p = _ml->_data; _ppvar = _ml->_pdata;
+/* insert compiler dependent ivdep like pragma */
+_PRAGMA_FOR_VECTOR_LOOP_
+_PRAGMA_FOR_INIT_ACC_LOOP_
+for (_iml = 0; _iml < _cntml_actual; ++_iml) {
+#else /* LAYOUT > 1 */ /*AoSoA*/
+#error AoSoA not implemented.
+for (;;) { /* help clang-format properly indent */
+#endif
+    int _nd_idx = _ni[_iml];
  _tsav = -1e20;
     _v = _vec_v[_nd_idx];
     _PRCELLSTATE_V
  v = _v;
- initmodel();
-}}
+ _PRCELLSTATE_V
+ initmodel(_threadargs_);
+}
+  }
+}
 
-static double _nrn_current(double _v){double _current=0.;v=_v;{ {
+static double _nrn_current(_threadargsproto_, double _v){double _current=0.;v=_v;{ {
    g = w * gmax * O ;
    i = g * ( v - Erev ) ;
    }
@@ -891,63 +985,143 @@ static double _nrn_current(double _v){double _current=0.;v=_v;{ {
 } return _current;
 }
 
-static void nrn_cur(NrnThread* _nt, Memb_list* _ml, int _type){
-int* _ni; double _rhs, _v; int _iml, _cntml_padded, _cntml_actual;
-#if CACHEVEC
-    _ni = _ml->_nodeindices;
+#if defined(ENABLE_CUDA_INTERFACE) && defined(_OPENACC)
+  void nrn_state_launcher(NrnThread*, Memb_list*, int, int);
+  void nrn_jacob_launcher(NrnThread*, Memb_list*, int, int);
+  void nrn_cur_launcher(NrnThread*, Memb_list*, int, int);
 #endif
+
+
+void nrn_cur(NrnThread* _nt, Memb_list* _ml, int _type) {
+double* _p; Datum* _ppvar; ThreadDatum* _thread;
+int* _ni; double _rhs, _g, _v, v; int _iml, _cntml_padded, _cntml_actual;
+    _ni = _ml->_nodeindices;
 _cntml_actual = _ml->_nodecount;
 _cntml_padded = _ml->_nodecount_padded;
+_thread = _ml->_thread;
+double * _vec_rhs = _nt->_actual_rhs;
+double * _vec_d = _nt->_actual_d;
+double * _vec_shadow_rhs = _nt->_shadow_rhs;
+double * _vec_shadow_d = _nt->_shadow_d;
+
+#if defined(ENABLE_CUDA_INTERFACE) && defined(_OPENACC) && !defined(DISABLE_OPENACC)
+  NrnThread* d_nt = acc_deviceptr(_nt);
+  Memb_list* d_ml = acc_deviceptr(_ml);
+  nrn_cur_launcher(d_nt, d_ml, _type, _cntml_actual);
+  return;
+#endif
+
+double * _nt_data = _nt->_data;
+double * _vec_v = _nt->_actual_v;
+int stream_id = _nt->stream_id;
+#if LAYOUT == 1 /*AoS*/
 for (_iml = 0; _iml < _cntml_actual; ++_iml) {
  _p = _ml->_data + _iml*_psize; _ppvar = _ml->_pdata + _iml*_ppsize;
+#elif LAYOUT == 0 /*SoA*/
+ _p = _ml->_data; _ppvar = _ml->_pdata;
+/* insert compiler dependent ivdep like pragma */
+_PRAGMA_FOR_VECTOR_LOOP_
+_PRAGMA_FOR_CUR_SYN_ACC_LOOP_
+for (_iml = 0; _iml < _cntml_actual; ++_iml) {
+#else /* LAYOUT > 1 */ /*AoSoA*/
+#error AoSoA not implemented.
+for (;;) { /* help clang-format properly indent */
+#endif
+    int _nd_idx = _ni[_iml];
     _v = _vec_v[_nd_idx];
     _PRCELLSTATE_V
- _g = _nrn_current(_v + .001);
- 	{ _rhs = _nrn_current(_v);
+ _g = _nrn_current(_threadargs_, _v + .001);
+ 	{ _rhs = _nrn_current(_threadargs_, _v);
  	}
  _g = (_g - _rhs)/.001;
- _g *=  1.e2/(_nd_area);
- _rhs *= 1.e2/(_nd_area);
-	VEC_RHS(_ni[_iml]) -= _rhs;
- 
-}}
+ double _mfact =  1.e2/(_nd_area);
+ _g *=  _mfact;
+ _rhs *= _mfact;
+ _PRCELLSTATE_G
 
-static void nrn_jacob(NrnThread* _nt, Memb_list* _ml, int _type){
-int* _ni; int _iml, _cntml_padded, _cntml_actual;
-#if CACHEVEC
-    _ni = _ml->_nodeindices;
+
+#ifdef _OPENACC
+  if(_nt->compute_gpu) {
+    #pragma acc atomic update
+    _vec_rhs[_nd_idx] -= _rhs;
+    #pragma acc atomic update
+    _vec_d[_nd_idx] += _g;
+  } else {
+    _vec_shadow_rhs[_iml] = _rhs;
+    _vec_shadow_d[_iml] = _g;
+  }
+#else
+  _vec_shadow_rhs[_iml] = _rhs;
+  _vec_shadow_d[_iml] = _g;
 #endif
+ }
+#ifdef _OPENACC
+    if(!(_nt->compute_gpu)) { 
+        for (_iml = 0; _iml < _cntml_actual; ++_iml) {
+           int _nd_idx = _ni[_iml];
+           _vec_rhs[_nd_idx] -= _vec_shadow_rhs[_iml];
+           _vec_d[_nd_idx] += _vec_shadow_d[_iml];
+        }
+#else
+ for (_iml = 0; _iml < _cntml_actual; ++_iml) {
+   int _nd_idx = _ni[_iml];
+   _vec_rhs[_nd_idx] -= _vec_shadow_rhs[_iml];
+   _vec_d[_nd_idx] += _vec_shadow_d[_iml];
+#endif
+ 
+}
+ 
+}
+
+void nrn_state(NrnThread* _nt, Memb_list* _ml, int _type) {
+double* _p; Datum* _ppvar; ThreadDatum* _thread;
+double v, _v = 0.0; int* _ni; int _iml, _cntml_padded, _cntml_actual;
+    _ni = _ml->_nodeindices;
 _cntml_actual = _ml->_nodecount;
 _cntml_padded = _ml->_nodecount_padded;
-for (_iml = 0; _iml < _cntml_actual; ++_iml) {
- _p = _ml->_data + _iml*_psize;
-	VEC_D(_ni[_iml]) += _g;
- 
-}}
+_thread = _ml->_thread;
 
-static void nrn_state(NrnThread* _nt, Memb_list* _ml, int _type){
-double _v = 0.0; int* _ni; int _iml, _cntml_padded, _cntml_actual;
-#if CACHEVEC
-    _ni = _ml->_nodeindices;
+#if defined(ENABLE_CUDA_INTERFACE) && defined(_OPENACC) && !defined(DISABLE_OPENACC)
+  NrnThread* d_nt = acc_deviceptr(_nt);
+  Memb_list* d_ml = acc_deviceptr(_ml);
+  nrn_state_launcher(d_nt, d_ml, _type, _cntml_actual);
+  return;
 #endif
-_cntml_actual = _ml->_nodecount;
-_cntml_padded = _ml->_nodecount_padded;
+
+double * _nt_data = _nt->_data;
+double * _vec_v = _nt->_actual_v;
+int stream_id = _nt->stream_id;
+#if LAYOUT == 1 /*AoS*/
 for (_iml = 0; _iml < _cntml_actual; ++_iml) {
  _p = _ml->_data + _iml*_psize; _ppvar = _ml->_pdata + _iml*_ppsize;
+#elif LAYOUT == 0 /*SoA*/
+ _p = _ml->_data; _ppvar = _ml->_pdata;
+/* insert compiler dependent ivdep like pragma */
+_PRAGMA_FOR_VECTOR_LOOP_
+_PRAGMA_FOR_STATE_ACC_LOOP_
+for (_iml = 0; _iml < _cntml_actual; ++_iml) {
+#else /* LAYOUT > 1 */ /*AoSoA*/
+#error AoSoA not implemented.
+for (;;) { /* help clang-format properly indent */
+#endif
+    int _nd_idx = _ni[_iml];
     _v = _vec_v[_nd_idx];
     _PRCELLSTATE_V
  v=_v;
- _PRCELLSTATE_V
 {
- { error = sparse(&_sparseobj1, 10, _slist1, _dlist1, _p, &t, dt, kstates,&_coef1, _linmat1);
- if(error){fprintf(stderr,"at line 142 in file SynNMDA10_2.mod:\n\n"); nrn_complain(_p); abort_run(error);}
- }}}
+ {  
+  #if !defined(_kinetic_kstates_NMDA10_2)
+    #define _kinetic_kstates_NMDA10_2 0
+  #endif
+  sparse_thread((SparseObj*)_thread[_spth1]._pvoid, 10, _slist1, _dlist1, &t, dt, _kinetic_kstates_NMDA10_2, _linmat1, _threadargs_);
+  }}}
 
 }
 
 static void terminal(){}
 
-static void _initlists() {
+static void _initlists(){
+ double _x; double* _p = &_x;
  int _i; static int _first = 1;
  int _cntml_actual=1;
  int _cntml_padded=1;
@@ -971,4 +1145,4 @@ static void _initlists() {
 
 _first = 0;
 }
- } // namespace coreneuron
+} // namespace coreneuron_lib


### PR DESCRIPTION
  - When mod file is not thread safe, we emit non-compilable
    code or a code than can be wrong when vectorisation is enabled.
    This results into confusing behaviour for end users.
  - Instead, it's safe and CPU/GPU compatible if user make the model
    theadsfae explicitly.
  - Update the test mod files accordingly.

Note : cpp files generated are not commited in this commit to avoid
the clutter. I will do that in next commit.