### PR TITLE
Avoid error with new clang/flex : implicit declaration of function 'isatty'

### DIFF
--- a/src/mod2c_core/lex.l
+++ b/src/mod2c_core/lex.l
@@ -1,6 +1,7 @@
 %{
 /* /local/src/master/nrn/src/nmodl/lex.l,v 4.2 1997/11/05 17:59:02 hines Exp */
 
+#include <unistd.h>
 #include "nmodlconf.h"
 
 #undef output


### PR DESCRIPTION


 * new clang version gives following error:
    ```
     lex.c:1611:40: error: implicit declaration of function 'isatty' is invalid in C99
     [-Werror,-Wimplicit-function-declaration]
        b->yy_is_interactive = file ? (isatty( fileno(file) ) > 0) : 0;
    ```