### PR TITLE
Avoid use of assert in OpenACC kernel along with use atomic capture

### DIFF
--- a/src/mod2c_core/nocpout.c
+++ b/src/mod2c_core/nocpout.c
@@ -3035,20 +3035,19 @@ sprintf(buf, "\
 \n  int _i = 0;\
 \n  #pragma acc atomic capture\
 \n  _i = _nsb->_cnt++;\
+\n#if !defined(_OPENACC)\
 \n  if (_i >= _nsb->_size) {\
-\n#if defined(_OPENACC)\
-\n    int NetSendBuffer_t_not_large_enough = 0;\
-\n    assert(NetSendBuffer_t_not_large_enough);\
-\n#else\
 \n    _nsb->grow();\
-\n#endif\
 \n  }\
-\n  _nsb->_sendtype[_i] = _sendtype;\
-\n  _nsb->_vdata_index[_i] = _i_vdata;\
-\n  _nsb->_weight_index[_i] = _weight_index;\
-\n  _nsb->_pnt_index[_i] = _ipnt;\
-\n  _nsb->_nsb_t[_i] = _t;\
-\n  _nsb->_nsb_flag[_i] = _flag;\
+\n#endif\
+\n  if (_i < _nsb->_size) {\
+\n    _nsb->_sendtype[_i] = _sendtype;\
+\n    _nsb->_vdata_index[_i] = _i_vdata;\
+\n    _nsb->_weight_index[_i] = _weight_index;\
+\n    _nsb->_pnt_index[_i] = _ipnt;\
+\n    _nsb->_nsb_t[_i] = _t;\
+\n    _nsb->_nsb_flag[_i] = _flag;\
+\n  }\
 \n}\n");
 		insertstr(q, buf);
 	}

--- a/test/validation/mod2c_core/cpp/SynNMDA10_2_2.cpp
+++ b/test/validation/mod2c_core/cpp/SynNMDA10_2_2.cpp
@@ -649,20 +649,19 @@ static void _net_send_buffering(NetSendBuffer_t* _nsb, int _sendtype, int _i_vda
   int _i = 0;
   #pragma acc atomic capture
   _i = _nsb->_cnt++;
+#if !defined(_OPENACC)
   if (_i >= _nsb->_size) {
-#if defined(_OPENACC)
-    int NetSendBuffer_t_not_large_enough = 0;
-    assert(NetSendBuffer_t_not_large_enough);
-#else
     _nsb->grow();
-#endif
   }
-  _nsb->_sendtype[_i] = _sendtype;
-  _nsb->_vdata_index[_i] = _i_vdata;
-  _nsb->_weight_index[_i] = _weight_index;
-  _nsb->_pnt_index[_i] = _ipnt;
-  _nsb->_nsb_t[_i] = _t;
-  _nsb->_nsb_flag[_i] = _flag;
+#endif
+  if (_i < _nsb->_size) {
+    _nsb->_sendtype[_i] = _sendtype;
+    _nsb->_vdata_index[_i] = _i_vdata;
+    _nsb->_weight_index[_i] = _weight_index;
+    _nsb->_pnt_index[_i] = _ipnt;
+    _nsb->_nsb_t[_i] = _t;
+    _nsb->_nsb_flag[_i] = _flag;
+  }
 }
  
 void _net_receive (Point_process* _pnt, int _weight_index, double _lflag) {

--- a/test/validation/mod2c_core/cpp/SynNMDA16_2.cpp
+++ b/test/validation/mod2c_core/cpp/SynNMDA16_2.cpp
@@ -945,20 +945,19 @@ static void _net_send_buffering(NetSendBuffer_t* _nsb, int _sendtype, int _i_vda
   int _i = 0;
   #pragma acc atomic capture
   _i = _nsb->_cnt++;
+#if !defined(_OPENACC)
   if (_i >= _nsb->_size) {
-#if defined(_OPENACC)
-    int NetSendBuffer_t_not_large_enough = 0;
-    assert(NetSendBuffer_t_not_large_enough);
-#else
     _nsb->grow();
-#endif
   }
-  _nsb->_sendtype[_i] = _sendtype;
-  _nsb->_vdata_index[_i] = _i_vdata;
-  _nsb->_weight_index[_i] = _weight_index;
-  _nsb->_pnt_index[_i] = _ipnt;
-  _nsb->_nsb_t[_i] = _t;
-  _nsb->_nsb_flag[_i] = _flag;
+#endif
+  if (_i < _nsb->_size) {
+    _nsb->_sendtype[_i] = _sendtype;
+    _nsb->_vdata_index[_i] = _i_vdata;
+    _nsb->_weight_index[_i] = _weight_index;
+    _nsb->_pnt_index[_i] = _ipnt;
+    _nsb->_nsb_t[_i] = _t;
+    _nsb->_nsb_flag[_i] = _flag;
+  }
 }
  
 void _net_receive (Point_process* _pnt, int _weight_index, double _lflag) {

--- a/test/validation/mod2c_core/cpp/zoidsyn.cpp
+++ b/test/validation/mod2c_core/cpp/zoidsyn.cpp
@@ -384,20 +384,19 @@ static void _net_send_buffering(NetSendBuffer_t* _nsb, int _sendtype, int _i_vda
   int _i = 0;
   #pragma acc atomic capture
   _i = _nsb->_cnt++;
+#if !defined(_OPENACC)
   if (_i >= _nsb->_size) {
-#if defined(_OPENACC)
-    int NetSendBuffer_t_not_large_enough = 0;
-    assert(NetSendBuffer_t_not_large_enough);
-#else
     _nsb->grow();
-#endif
   }
-  _nsb->_sendtype[_i] = _sendtype;
-  _nsb->_vdata_index[_i] = _i_vdata;
-  _nsb->_weight_index[_i] = _weight_index;
-  _nsb->_pnt_index[_i] = _ipnt;
-  _nsb->_nsb_t[_i] = _t;
-  _nsb->_nsb_flag[_i] = _flag;
+#endif
+  if (_i < _nsb->_size) {
+    _nsb->_sendtype[_i] = _sendtype;
+    _nsb->_vdata_index[_i] = _i_vdata;
+    _nsb->_weight_index[_i] = _weight_index;
+    _nsb->_pnt_index[_i] = _ipnt;
+    _nsb->_nsb_t[_i] = _t;
+    _nsb->_nsb_flag[_i] = _flag;
+  }
 }
  
 void _net_receive (Point_process* _pnt, int _weight_index, double _lflag) {


### PR DESCRIPTION
 * During psolve-direct PR in coreneuron (#528), we saw that following
   code produces random errors:

        #pragma acc atomic capture
        _i = _nsb->_cnt++;
        if (_i >= _nsb->_size) {
            int NetSendBuffer_t_not_large_enough = 0;
            assert(NetSendBuffer_t_not_large_enough);
        }

    In the presence of assert(), _i value is duplicated. This error is
    not easily reproducible in standalone example and also happens
    randomly during the execution. The code works fine if we use -O0
    optimization.
  * It's not clear if this is a compiler bug. For now, avoid use assert()
    in the atomic capture.
  * Error handling will be done in CoreNEURON by checking the `nsb->count`
    in the `update_net_send_buffer_on_host()` implementation.
  * Update the test code