### PR TITLE
Remove warning for automatic cast to int

### DIFF
--- a/src/mod2c_core/sens.c
+++ b/src/mod2c_core/sens.c
@@ -150,6 +150,7 @@ void add_sens_statelist(s)
 void sensmassage(type, qfun, fn)
 	int type;
 	Item *qfun;
+	int fn;
 {
 /*qfun is the list symbol for the name of the derivative block. It has
 a count of the number of state variables used.  A copy of this symbol


### PR DESCRIPTION
This generate a warning in coreneuron build.
Once it is merge, let update submodule in CoreNeuron