### PR TITLE
Support fast_imem on CPU in GPU builds.

### DIFF
--- a/src/mod2c_core/noccout.c
+++ b/src/mod2c_core/noccout.c
@@ -181,6 +181,7 @@ static void rhs_d_pnt_race(const char* r, const char* d) {
 \n           int _nd_idx = _ni[_iml];\
 \n           _vec_rhs[_nd_idx] %s _vec_shadow_rhs[_iml];\
 \n           _vec_d[_nd_idx] %s _vec_shadow_d[_iml];\
+%s\
 \n        }\
 \n#else\
 \n for (_iml = 0; _iml < _cntml_actual; ++_iml) {\
@@ -189,7 +190,7 @@ static void rhs_d_pnt_race(const char* r, const char* d) {
 \n   _vec_d[_nd_idx] %s _vec_shadow_d[_iml];\
 %s\
 \n#endif\
-\n", r, d, r, d, print_fast_imem_code());
+\n", r, d, print_fast_imem_code(), r, d, print_fast_imem_code());
   P(buf);
 }
 


### PR DESCRIPTION
https://github.com/BlueBrain/CoreNeuron/issues/670 should be fixed once the CoreNEURON submodule for mod2c includes this change.

Without this patch, the code between the two `// MARKER` comments below was not emitted.
```c++
for (_iml = 0; _iml < _cntml_actual; ++_iml) {
#ifdef _OPENACC
    if (_nt->compute_gpu) {
#pragma acc atomic update
        _vec_rhs[_nd_idx] += _rhs;
#pragma acc atomic update
        _vec_d[_nd_idx] -= _g;
        if (_nt->nrn_fast_imem) {
#pragma acc atomic update
            _nt->nrn_fast_imem->nrn_sav_rhs[_nd_idx] += _rhs;
#pragma acc atomic update
            _nt->nrn_fast_imem->nrn_sav_d[_nd_idx] -= _g;
        }
    } else {
        _vec_shadow_rhs[_iml] = _rhs;
        _vec_shadow_d[_iml] = _g;
    }
#else
    _vec_shadow_rhs[_iml] = _rhs;
    _vec_shadow_d[_iml] = _g;
#endif
}
#ifdef _OPENACC
if (!(_nt->compute_gpu)) {
    for (_iml = 0; _iml < _cntml_actual; ++_iml) {
        int _nd_idx = _ni[_iml];
        _vec_rhs[_nd_idx] += _vec_shadow_rhs[_iml];
        _vec_d[_nd_idx] -= _vec_shadow_d[_iml];
        // MARKER
        if (_nt->nrn_fast_imem) {
            _nt->nrn_fast_imem->nrn_sav_rhs[_nd_idx] += _vec_shadow_rhs[_iml];
            _nt->nrn_fast_imem->nrn_sav_d[_nd_idx] -= _vec_shadow_d[_iml];
        }
        // MARKER
    }
}
#else
for (_iml = 0; _iml < _cntml_actual; ++_iml) {
    int _nd_idx = _ni[_iml];
    _vec_rhs[_nd_idx] += _vec_shadow_rhs[_iml];
    _vec_d[_nd_idx] -= _vec_shadow_d[_iml];
    if (_nt->nrn_fast_imem) {
        _nt->nrn_fast_imem->nrn_sav_rhs[_nd_idx] += _vec_shadow_rhs[_iml];
        _nt->nrn_fast_imem->nrn_sav_d[_nd_idx] -= _vec_shadow_d[_iml];
    }
}
#endif
```