### PR TITLE
Fix for code generation with RANGE variables as an array

### DIFF
--- a/src/mod2c_core/nocpout.c
+++ b/src/mod2c_core/nocpout.c
@@ -1908,7 +1908,7 @@ static void defs_h(s)
 	Item *q;
 	
 	if (s->subtype & ARRAY) {
-		Sprintf(buf, "#define %s (_p + %d*_STRIDE)\n", s->name, parraycount);
+		Sprintf(buf, "#define %s (_p + %d*_STRIDE*%d)\n", s->name, parraycount, s->araydim);
 		q = lappendstr(defs_list, buf);
 	} else {
 		Sprintf(buf, "#define %s _p[%d*_STRIDE]\n", s->name, parraycount);

--- a/test/validation/mod/NaSm.mod
+++ b/test/validation/mod/NaSm.mod
@@ -43,15 +43,15 @@ ASSIGNED {
 	v  (mV)
         ina (mA/cm2)
 	celsius		(degC)
+	mtau[2]
  	minf
-	mtau
-	gnasm
+	gnasm[1]
 }
  
 BREAKPOINT {
         SOLVE states METHOD cnexp
-        gnasm = gnasmbar*m
-        ina = gnasm*(v - ena)
+        gnasm[0] = gnasmbar*m
+        ina = gnasm[0]*(v - ena)
   
 }
  
@@ -66,7 +66,7 @@ INITIAL {
 DERIVATIVE states {  :Computes states variable m at the current v and dt.
         rates(v)      
        
-	m' = ( minf - m ) / mtau
+	m' = ( minf - m ) / mtau[1]
 }
  
 PROCEDURE rates(v) {  :Computes rate and other constants at current v. Call once from HOC to initialize inf at resting v.
@@ -74,7 +74,7 @@ PROCEDURE rates(v) {  :Computes rate and other constants at current v. Call once
         q10 = 2.5
 	tadj=q10^((celsius-Etemp)/10)
         minf=1/(1+exp(-(v-Vsm)/ksm))
-	mtau=tom/(exp(-(v-Vtm)/ktm)+exp((v-Vtm)/ktm))/tadj
+	mtau[1]=tom/(exp(-(v-Vtm)/ktm)+exp((v-Vtm)/ktm))/tadj
       
 }
  


### PR DESCRIPTION
* With SOA layout, array variable is stored contigiously in
  memory. For example, RANGE variable mtau[2] has values
  [1 2   2 3   4 5 ... ]
* Our current index calculation was done as

```c++
   #define mtau (_p + OFFSET + i)
   for (int i=0; i < N; i++) {}
       mtau[0] = X
       mtau[1] = X
   }
```

   Note that even if mtau is an array, it's not being incremented by 2. The access becomes
```c++
   mtau (_p + OFFSET + 0)[0]
   mtau (_p + OFFSET + 0)[1]       <- this and next line is the same memory access!
   mtau (_p + OFFSET + 1)[0]
   mtau (_p + OFFSET + 1)[1]
```


   Hence, we need to define top level macro as:
```c++
   #define mtau (_p + OFFSET + i * ARRAY_LENGTH)
   i.e.
   #define mtau (_p + OFFSET + i * 2)
```