### PR TITLE
Fix code generation with partial initialization of arrays

### DIFF
--- a/src/mod2c_core/parsact.c
+++ b/src/mod2c_core/parsact.c
@@ -958,7 +958,7 @@ s->name, s->name, s->name, s->name);
 	ITERATE(q, table) {
 		s = SYM(q);
 		if (s->subtype & ARRAY) {
-			Sprintf(buf, "static double *_t_%s[%d] = nullptr;\n",
+			Sprintf(buf, "static double *_t_%s[%d] = {nullptr};\n",
 			 s->name, s->araydim);
 		}else{
 			Sprintf(buf, "static double *_t_%s = nullptr;\n", s->name);


### PR DESCRIPTION
With array variables in TABLE of `glia__dbbs_mod_collection__Cav2_3__0.mod` we get:

```console
  x86_64/corenrn/mod2c/glia__dbbs_mod_collection__Cav2_3__0.cpp:270:17: error: array initializer must be an initializer list
  static double *_t_inf[2] = nullptr;
                ^
```