### PR TITLE
Remove omp atomic update and critical

### DIFF
--- a/src/mod2c_core/parsact.c
+++ b/src/mod2c_core/parsact.c
@@ -1276,12 +1276,14 @@ void nrnmutex(int on, Item* q) { /* MUTEXLOCK or MUTEXUNLOCK */
 			diag("MUTEXLOCK invoked after MUTEXLOCK", (char*)0);
 		}
 		toggle = 1;
+		replacstr(q, "");
 		protect_include_ = 1;
 	}else if (on == 0) {
 		if (toggle != 1) {
 			diag("MUTEXUNLOCK invoked with no earlier MUTEXLOCK", (char*)0);
 		}
 		toggle = 0;
+		replacstr(q, "");
 		protect_include_ = 1;
 	}else{
 		if (toggle != 0) {

--- a/src/mod2c_core/parsact.c
+++ b/src/mod2c_core/parsact.c
@@ -1263,7 +1263,7 @@ void threadsafe(char* s) {
 
 Item* protect_astmt(Item* q1, Item* q2) { /* PROTECT, ';' */
 	Item* q;
-	replacstr(q1, "#pragma omp atomic update\n #pragma acc atomic update\n");
+	replacstr(q1, "#pragma acc atomic update\n");
 	q = insertstr(q2->next, "\n");
 	protect_include_ = 1;
 	return q;
@@ -1276,14 +1276,12 @@ void nrnmutex(int on, Item* q) { /* MUTEXLOCK or MUTEXUNLOCK */
 			diag("MUTEXLOCK invoked after MUTEXLOCK", (char*)0);
 		}
 		toggle = 1;
-		replacstr(q, "#pragma omp critical\n {\n");
 		protect_include_ = 1;
 	}else if (on == 0) {
 		if (toggle != 1) {
 			diag("MUTEXUNLOCK invoked with no earlier MUTEXLOCK", (char*)0);
 		}
 		toggle = 0;
-		replacstr(q, "\n}\n");
 		protect_include_ = 1;
 	}else{
 		if (toggle != 0) {

--- a/test/validation/mod2c_core/cpp/NaSm.cpp
+++ b/test/validation/mod2c_core/cpp/NaSm.cpp
@@ -357,7 +357,7 @@ static inline void initmodel(_threadargsproto_) {
   m = m0;
  {
    rates ( _threadargscomma_ v ) ;
-    m = minf + 1.1 ;
+   m = minf + 1.1 ;
  }
  
 }

--- a/test/validation/mod2c_core/cpp/NaSm.cpp
+++ b/test/validation/mod2c_core/cpp/NaSm.cpp
@@ -357,10 +357,7 @@ static inline void initmodel(_threadargsproto_) {
   m = m0;
  {
    rates ( _threadargscomma_ v ) ;
-   #pragma omp critical
-   {
     m = minf + 1.1 ;
-   }
  }
  
 }

--- a/test/validation/mod2c_core/cpp/Nap_E.cpp
+++ b/test/validation/mod2c_core/cpp/Nap_E.cpp
@@ -363,7 +363,6 @@ static int  rates ( _threadargsproto_ ) {
      }
    hAlpha = ( 0.00001 * ( v - - 50.0 ) ) / ( 1.0 - ( exp ( - ( v - - 50.0 ) / 13.0 ) ) ) ;
    if ( v  == - 75.0 ) {
-     #pragma omp atomic update
      #pragma acc atomic update
      v = v + 0.0001 ;
      }


### PR DESCRIPTION
Take number 2 on #89 .
Having 
```
#pragma omp atomic update
#pragma acc atomic update
```
with OpenMP and GPU/OpenACC enabled with `mod2c` generates the following issue: 
```
NVC++-S-0155-Invalid atomic region.  (x86_64/corenrn/mod2c/axial.cpp: 346)
NVC++/x86-64 Linux 22.3-0: compilation completed with severe errors
```
For this purpose `#pragma omp atomic update` can be removed since we never have `#pragma omp simd` in `mod2c` and `#pragma ivdep` is disabled when we have either `PROTECT`, `MUTEX` or `MUTEUNLOCK`.
For the same reason I think `#pragma omp critical` can also be removed.